### PR TITLE
feat: add customer portal pages and dynamic forms

### DIFF
--- a/src/app/(customer)/account/page.tsx
+++ b/src/app/(customer)/account/page.tsx
@@ -1,0 +1,197 @@
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AccountPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <div className="p-10">Please log in.</div>;
+  }
+
+  const [{ data: profile }, { data: customer }] = await Promise.all([
+    supabase.from("profiles").select("*").eq("id", user.id).single(),
+    supabase.from("customers").select("*").eq("owner_id", user.id).single(),
+  ]);
+
+  const address: any = customer?.shipping_address || {};
+
+  async function updateProfile(formData: FormData) {
+    "use server";
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    await supabase
+      .from("profiles")
+      .update({
+        full_name: formData.get("full_name"),
+        phone: formData.get("phone"),
+      })
+      .eq("id", user?.id);
+  }
+
+  async function updateCompany(formData: FormData) {
+    "use server";
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const { data: cust } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("owner_id", user?.id)
+      .single();
+    if (cust) {
+      await supabase
+        .from("customers")
+        .update({
+          name: formData.get("name"),
+          website: formData.get("website"),
+        })
+        .eq("id", cust.id);
+    }
+  }
+
+  async function updateAddress(formData: FormData) {
+    "use server";
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const { data: cust } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("owner_id", user?.id)
+      .single();
+    if (cust) {
+      const addr = {
+        street: formData.get("street"),
+        city: formData.get("city"),
+        state: formData.get("state"),
+        postal_code: formData.get("postal_code"),
+        country: formData.get("country"),
+      };
+      await supabase
+        .from("customers")
+        .update({ shipping_address: addr })
+        .eq("id", cust.id);
+    }
+  }
+
+  async function updatePrefs(formData: FormData) {
+    "use server";
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    await supabase
+      .from("profiles")
+      .update({ region: formData.get("region") })
+      .eq("id", user?.id);
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 space-y-10">
+      <h1 className="text-2xl font-semibold">Account</h1>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Profile</h2>
+        <form action={updateProfile} className="space-y-2">
+          <input
+            name="full_name"
+            defaultValue={profile?.full_name ?? ""}
+            placeholder="Full name"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="phone"
+            defaultValue={profile?.phone ?? ""}
+            placeholder="Phone"
+            className="border p-2 rounded w-full"
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Company</h2>
+        <form action={updateCompany} className="space-y-2">
+          <input
+            name="name"
+            defaultValue={customer?.name ?? ""}
+            placeholder="Company name"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="website"
+            defaultValue={customer?.website ?? ""}
+            placeholder="Website"
+            className="border p-2 rounded w-full"
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Address</h2>
+        <form action={updateAddress} className="space-y-2">
+          <input
+            name="street"
+            defaultValue={address.street ?? ""}
+            placeholder="Street"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="city"
+            defaultValue={address.city ?? ""}
+            placeholder="City"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="state"
+            defaultValue={address.state ?? ""}
+            placeholder="State"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="postal_code"
+            defaultValue={address.postal_code ?? ""}
+            placeholder="Postal code"
+            className="border p-2 rounded w-full"
+          />
+          <input
+            name="country"
+            defaultValue={address.country ?? ""}
+            placeholder="Country"
+            className="border p-2 rounded w-full"
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Preferences</h2>
+        <form action={updatePrefs} className="space-y-2">
+          <input
+            name="region"
+            defaultValue={profile?.region ?? ""}
+            placeholder="Region"
+            className="border p-2 rounded w-full"
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/(customer)/dashboard/page.tsx
+++ b/src/app/(customer)/dashboard/page.tsx
@@ -1,0 +1,135 @@
+import { createClient } from "@/lib/supabase/server";
+
+export default async function DashboardPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <div className="p-10">Please log in.</div>;
+  }
+
+  const { data: customer } = await supabase
+    .from("customers")
+    .select("id")
+    .eq("owner_id", user.id)
+    .single();
+
+  const customerId = customer?.id;
+
+  const [partsRes, quotesRes, ordersRes] = await Promise.all([
+    supabase
+      .from("parts")
+      .select("id,file_name,created_at")
+      .eq("owner_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(5),
+    customerId
+      ? supabase
+          .from("quotes")
+          .select("id,status,created_at")
+          .eq("customer_id", customerId)
+          .order("created_at", { ascending: false })
+          .limit(5)
+      : Promise.resolve({ data: [] }),
+    customerId
+      ? supabase
+          .from("orders")
+          .select("id,status,total,created_at")
+          .eq("customer_id", customerId)
+          .neq("status", "closed")
+          .order("created_at", { ascending: false })
+          .limit(5)
+      : Promise.resolve({ data: [] }),
+  ]);
+
+  const quotes = quotesRes.data ?? [];
+  const parts = partsRes.data ?? [];
+  const orders = ordersRes.data ?? [];
+
+  let messages: any[] = [];
+  if (customerId) {
+    const quoteIds = quotes.map((q: any) => q.id);
+    if (quoteIds.length) {
+      const { data: msgData } = await supabase
+        .from("messages")
+        .select("id,content,created_at")
+        .in("quote_id", quoteIds)
+        .order("created_at", { ascending: false })
+        .limit(5);
+      messages = msgData ?? [];
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-8">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Recent Quotes</h2>
+        <ul className="space-y-1">
+          {quotes.length ? (
+            quotes.map((q: any) => (
+              <li key={q.id} className="text-sm">
+                <a href={`/quote/${q.id}`} className="text-blue-600 underline">
+                  {q.id}
+                </a>{" "}- {q.status}
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-gray-500">No quotes</li>
+          )}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Recent Messages</h2>
+        <ul className="space-y-1">
+          {messages.length ? (
+            messages.map((m: any) => (
+              <li key={m.id} className="text-sm">
+                {m.content}
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-gray-500">No messages</li>
+          )}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Recent Parts</h2>
+        <ul className="space-y-1">
+          {parts.length ? (
+            parts.map((p: any) => (
+              <li key={p.id} className="text-sm">
+                {p.file_name}
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-gray-500">No parts</li>
+          )}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Open Orders</h2>
+        <ul className="space-y-1">
+          {orders.length ? (
+            orders.map((o: any) => (
+              <li key={o.id} className="text-sm">
+                <a href={`/order/${o.id}`} className="text-blue-600 underline">
+                  {o.id}
+                </a>{" "}- {o.status}
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-gray-500">No open orders</li>
+          )}
+        </ul>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/(customer)/forms/[formId]/page.tsx
+++ b/src/app/(customer)/forms/[formId]/page.tsx
@@ -1,0 +1,44 @@
+import DynamicForm from "@/components/forms/DynamicForm";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { formId: string };
+}
+
+export default async function FormPage({ params }: Props) {
+  const supabase = createClient();
+  const { data: form } = await supabase
+    .from("custom_forms")
+    .select("id,name,description,schema")
+    .eq("id", params.formId)
+    .single();
+
+  async function submit(formData: FormData) {
+    "use server";
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const entries = Object.fromEntries(formData.entries());
+    await supabase.from("custom_form_responses").insert({
+      form_id: params.formId,
+      respondent_id: user?.id,
+      data: entries,
+    });
+  }
+
+  if (!form) {
+    return <div className="p-10">Form not found.</div>;
+  }
+
+  return (
+    <div className="max-w-xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-2">{form.name}</h1>
+      {form.description && (
+        <p className="text-sm text-gray-500 mb-4">{form.description}</p>
+      )}
+      <DynamicForm schema={form.schema} action={submit} />
+    </div>
+  );
+}
+

--- a/src/app/(customer)/order/[id]/page.tsx
+++ b/src/app/(customer)/order/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function OrderPage({ params }: Props) {
+  const supabase = createClient();
+  const { data: order } = await supabase
+    .from("orders")
+    .select("id,status,total,created_at,order_items(id,part_id,quantity,line_total)")
+    .eq("id", params.id)
+    .single();
+
+  if (!order) {
+    return <div className="p-10">Order not found.</div>;
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-4">Order {order.id}</h1>
+      <p className="mb-2">Status: {order.status}</p>
+      <p className="mb-4">Total: {order.total}</p>
+      <h2 className="text-lg font-medium mb-2">Items</h2>
+      <ul className="space-y-2">
+        {order.order_items?.map((item: any) => (
+          <li key={item.id} className="text-sm">
+            Part {item.part_id} x {item.quantity} - {item.line_total}
+          </li>
+        ))}
+        {!order.order_items?.length && (
+          <li className="text-sm text-gray-500">No items</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/(customer)/orders/page.tsx
+++ b/src/app/(customer)/orders/page.tsx
@@ -1,0 +1,56 @@
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  searchParams: { [key: string]: string | string[] | undefined };
+}
+
+const PAGE_SIZE = 10;
+
+export default async function OrdersPage({ searchParams }: Props) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <div className="p-10">Please log in.</div>;
+  }
+
+  const { data: customer } = await supabase
+    .from("customers")
+    .select("id")
+    .eq("owner_id", user.id)
+    .single();
+
+  const page = Number(searchParams.page ?? "1");
+  const from = (page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  const { data: orders } = await supabase
+    .from("orders")
+    .select("id,status,total,created_at")
+    .eq("customer_id", customer?.id)
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Orders</h1>
+      <ul className="space-y-2">
+        {orders?.map((o) => (
+          <li key={o.id} className="border p-4 rounded">
+            <a href={`/order/${o.id}`} className="text-blue-600 underline">
+              {o.id}
+            </a>
+            <p className="text-sm">Status: {o.status}</p>
+            <p className="text-sm">Total: {o.total}</p>
+          </li>
+        ))}
+        {!orders?.length && (
+          <li className="text-sm text-gray-500">No orders</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/(customer)/parts/page.tsx
+++ b/src/app/(customer)/parts/page.tsx
@@ -1,0 +1,108 @@
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  searchParams: { [key: string]: string | string[] | undefined };
+}
+
+const PAGE_SIZE = 10;
+
+export default async function PartsPage({ searchParams }: Props) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <div className="p-10">Please log in.</div>;
+  }
+
+  const page = Number(searchParams.page ?? "1");
+  const q = typeof searchParams.q === "string" ? searchParams.q : "";
+  const from = (page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  let query = supabase
+    .from("parts")
+    .select("id,file_name,preview_url,created_at", { count: "exact" })
+    .eq("owner_id", user.id);
+
+  if (q) {
+    query = query.ilike("file_name", `%${q}%`);
+  }
+
+  const { data: partsData, count } = await query
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  const parts = await Promise.all(
+    (partsData ?? []).map(async (p) => {
+      let preview: string | null = null;
+      if (p.preview_url) {
+        const { data } = await supabase
+          .storage
+          .from("parts")
+          .createSignedUrl(p.preview_url, 3600);
+        preview = data?.signedUrl ?? null;
+      }
+      return { ...p, preview };
+    })
+  );
+
+  const totalPages = count ? Math.ceil(count / PAGE_SIZE) : 1;
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Parts</h1>
+
+      <form className="mb-4 flex space-x-2">
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search"
+          className="border p-2 rounded flex-1"
+        />
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          Filter
+        </button>
+      </form>
+
+      <ul className="grid grid-cols-2 gap-4">
+        {parts.map((p) => (
+          <li key={p.id} className="border rounded p-2">
+            {p.preview && (
+              <img
+                src={p.preview}
+                alt={p.file_name}
+                className="w-full h-32 object-contain mb-2"
+              />
+            )}
+            <p className="text-sm">{p.file_name}</p>
+          </li>
+        ))}
+        {!parts.length && (
+          <li className="text-sm text-gray-500">No parts found</li>
+        )}
+      </ul>
+
+      <div className="mt-4 flex justify-between">
+        {page > 1 && (
+          <a
+            href={`?q=${encodeURIComponent(q)}&page=${page - 1}`}
+            className="text-blue-600"
+          >
+            Previous
+          </a>
+        )}
+        {page < totalPages && (
+          <a
+            href={`?q=${encodeURIComponent(q)}&page=${page + 1}`}
+            className="ml-auto text-blue-600"
+          >
+            Next
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/forms/DynamicForm.tsx
+++ b/src/components/forms/DynamicForm.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+interface Props {
+  schema: any;
+  action: (formData: FormData) => void;
+}
+
+export default function DynamicForm({ schema, action }: Props) {
+  const properties = schema?.properties || {};
+  const required: string[] = schema?.required || [];
+
+  return (
+    <form action={action} className="space-y-4">
+      {Object.entries(properties).map(([key, config]: any) => {
+        const isRequired = required.includes(key);
+        let field = null;
+        if (config.enum) {
+          field = (
+            <select
+              name={key}
+              required={isRequired}
+              className="border p-2 rounded w-full"
+              defaultValue=""
+            >
+              <option value="" disabled>
+                Select...
+              </option>
+              {config.enum.map((opt: string) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          );
+        } else if (config.type === "boolean") {
+          field = (
+            <input type="checkbox" name={key} className="mr-2" />
+          );
+        } else if (config.type === "number" || config.type === "integer") {
+          field = (
+            <input
+              type="number"
+              name={key}
+              required={isRequired}
+              className="border p-2 rounded w-full"
+            />
+          );
+        } else {
+          field = (
+            <input
+              type="text"
+              name={key}
+              required={isRequired}
+              className="border p-2 rounded w-full"
+            />
+          );
+        }
+        return (
+          <div key={key}>
+            <label className="block text-sm font-medium mb-1">
+              {config.title || key}
+            </label>
+            {field}
+          </div>
+        );
+      })}
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+        Submit
+      </button>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement customer dashboard, parts, orders, order detail, account, and form pages
- add generic DynamicForm component with Supabase-backed submissions
- support signed part previews and account server actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9b07b36c8322824cbb7ccaacfd29