### PR TITLE
feat(admin): add dashboard KPIs and feeds

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,65 @@
+import KpiCard from "@/components/admin/KpiCard";
+import ListFeed from "@/components/admin/ListFeed";
+import { getKpis, getFeeds } from "@/lib/metrics";
+import { requireAdmin } from "@/lib/auth";
+
+export default async function AdminDashboardPage() {
+  await requireAdmin();
+
+  const [kpis, feeds] = await Promise.all([getKpis(), getFeeds()]);
+
+  return (
+    <div className="max-w-6xl mx-auto py-10 space-y-8">
+      <h1 className="text-2xl font-semibold">Admin Dashboard</h1>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <KpiCard
+          title="Quotes by Status"
+          value={Object.entries(kpis.quotes_by_status)
+            .map(([s, c]) => `${s}: ${c}`)
+            .join(", ")}
+        />
+        <KpiCard
+          title="Revenue (30d)"
+          value={`$${kpis.revenue_30d.toFixed(2)}`}
+        />
+        <KpiCard
+          title="Conversion Rate"
+          value={`${(kpis.conversion_rate * 100).toFixed(1)}%`}
+        />
+        <KpiCard title="Abandoned Funnel" value={kpis.abandoned_funnel} />
+        <KpiCard
+          title="Orders in Production"
+          value={kpis.orders_in_production}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <ListFeed
+          title="Recent Messages"
+          items={feeds.recent_messages.map((m: any) => ({
+            id: m.id,
+            primary: m.content,
+            secondary: new Date(m.created_at).toLocaleString(),
+          }))}
+        />
+        <ListFeed
+          title="Latest Uploads"
+          items={feeds.latest_uploads.map((p: any) => ({
+            id: p.id,
+            primary: p.file_name,
+            secondary: new Date(p.created_at).toLocaleString(),
+          }))}
+        />
+        <ListFeed
+          title="Workload"
+          items={feeds.workload.map((o: any) => ({
+            id: o.id,
+            primary: o.id,
+            secondary: o.status,
+          }))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/KpiCard.tsx
+++ b/src/components/admin/KpiCard.tsx
@@ -1,0 +1,13 @@
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+}
+
+export default function KpiCard({ title, value }: KpiCardProps) {
+  return (
+    <div className="p-4 border rounded-md shadow-sm">
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/src/components/admin/ListFeed.tsx
+++ b/src/components/admin/ListFeed.tsx
@@ -1,0 +1,32 @@
+interface ListFeedItem {
+  id: string | number;
+  primary: string;
+  secondary?: string;
+}
+
+interface ListFeedProps {
+  title: string;
+  items: ListFeedItem[];
+}
+
+export default function ListFeed({ title, items }: ListFeedProps) {
+  return (
+    <section>
+      <h2 className="text-lg font-medium mb-2">{title}</h2>
+      <ul className="space-y-1 text-sm">
+        {items.length ? (
+          items.map((item) => (
+            <li key={item.id} className="flex justify-between">
+              <span>{item.primary}</span>
+              {item.secondary && (
+                <span className="text-gray-500">{item.secondary}</span>
+              )}
+            </li>
+          ))
+        ) : (
+          <li className="text-gray-500">No items</li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,82 @@
+import { createClient } from "./supabase/server";
+
+export async function getKpis() {
+  const supabase = createClient();
+  const now = new Date();
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(now.getDate() - 30);
+
+  const [quotesRes, paymentsRes, abandonedRes, productionRes] =
+    await Promise.all([
+      supabase.from("quotes").select("status"),
+      supabase
+        .from("payments")
+        .select("amount")
+        .gte("created_at", thirtyDaysAgo.toISOString()),
+      supabase
+        .from("abandoned_quotes")
+        .select("*", { count: "exact", head: true })
+        .eq("is_claimed", false),
+      supabase
+        .from("orders")
+        .select("*", { count: "exact", head: true })
+        .eq("status", "in_production"),
+    ]);
+
+  const quotesByStatus = (quotesRes.data ?? []).reduce(
+    (acc: Record<string, number>, q: any) => {
+      acc[q.status] = (acc[q.status] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const revenue30d = (paymentsRes.data ?? []).reduce(
+    (sum: number, p: any) => sum + Number(p.amount || 0),
+    0
+  );
+
+  const sent = (quotesRes.data ?? []).filter((q: any) => q.status === "sent")
+    .length;
+  const accepted = (quotesRes.data ?? []).filter((q: any) =>
+    ["accepted", "paid", "in_production", "completed"].includes(q.status)
+  ).length;
+  const conversionRate = sent ? accepted / sent : 0;
+
+  return {
+    quotes_by_status: quotesByStatus,
+    revenue_30d: revenue30d,
+    conversion_rate: conversionRate,
+    abandoned_funnel: abandonedRes.count ?? 0,
+    orders_in_production: productionRes.count ?? 0,
+  };
+}
+
+export async function getFeeds() {
+  const supabase = createClient();
+
+  const [messagesRes, uploadsRes, workloadRes] = await Promise.all([
+    supabase
+      .from("messages")
+      .select("id,content,created_at")
+      .order("created_at", { ascending: false })
+      .limit(5),
+    supabase
+      .from("parts")
+      .select("id,file_name,created_at")
+      .order("created_at", { ascending: false })
+      .limit(5),
+    supabase
+      .from("orders")
+      .select("id,status,created_at")
+      .not("status", "eq", "closed")
+      .order("created_at", { ascending: false })
+      .limit(5),
+  ]);
+
+  return {
+    recent_messages: messagesRes.data ?? [],
+    latest_uploads: uploadsRes.data ?? [],
+    workload: workloadRes.data ?? [],
+  };
+}


### PR DESCRIPTION
## Summary
- add server-side metrics utilities for admin KPIs and feeds
- create reusable admin `KpiCard` and `ListFeed` components
- implement admin dashboard showing KPIs and data feeds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cf46700832299216ce86d8c7bc9