### PR TITLE
feat(admin): add CRUD pages and quote repricing

### DIFF
--- a/src/app/admin/abandoned/page.tsx
+++ b/src/app/admin/abandoned/page.tsx
@@ -1,0 +1,52 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AbandonedAdminPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: abandoned } = await supabase
+    .from("abandoned_quotes")
+    .select("id,email,created_at")
+    .order("created_at", { ascending: false });
+
+  async function convert(formData: FormData) {
+    "use server";
+    const id = formData.get("id") as string;
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("abandoned_quotes")
+      .select("email")
+      .eq("id", id)
+      .single();
+    if (data?.email) {
+      await supabase.from("customers").insert({ name: data.email }).select("id");
+      await supabase.from("abandoned_quotes").delete().eq("id", id);
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Abandoned Quotes</h1>
+      <ul className="space-y-4">
+        {abandoned?.map((a) => (
+          <li key={a.id} className="border p-4 rounded">
+            <p className="text-sm">{a.email}</p>
+            <form action={convert}>
+              <input type="hidden" name="id" value={a.id} />
+              <button
+                type="submit"
+                className="mt-2 px-3 py-1 bg-green-600 text-white rounded"
+              >
+                Convert to Customer
+              </button>
+            </form>
+          </li>
+        ))}
+        {!abandoned?.length && (
+          <li className="text-sm text-gray-500">No abandoned quotes</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/customers/[id]/page.tsx
+++ b/src/app/admin/customers/[id]/page.tsx
@@ -1,0 +1,58 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function CustomerDetailPage({ params }: Props) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: customer } = await supabase
+    .from("customers")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+
+  async function updateCustomer(formData: FormData) {
+    "use server";
+    const name = formData.get("name") as string;
+    const notes = formData.get("notes") as string;
+    const supabase = createClient();
+    await supabase
+      .from("customers")
+      .update({ name, notes })
+      .eq("id", params.id);
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Customer {customer?.name}</h1>
+      <form action={updateCustomer} className="space-y-4">
+        <div>
+          <label className="block text-sm">Name</label>
+          <input
+            name="name"
+            defaultValue={customer?.name ?? ""}
+            className="border p-1 rounded w-full"
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Notes</label>
+          <textarea
+            name="notes"
+            defaultValue={customer?.notes ?? ""}
+            className="border p-1 rounded w-full"
+          />
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Save
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/admin/customers/page.tsx
+++ b/src/app/admin/customers/page.tsx
@@ -1,0 +1,34 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function CustomersAdminPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: customers } = await supabase
+    .from("customers")
+    .select("id,name,created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Customers</h1>
+      <ul className="space-y-2">
+        {customers?.map((c) => (
+          <li key={c.id} className="border p-4 rounded">
+            <a
+              href={`/admin/customers/${c.id}`}
+              className="text-blue-600 underline"
+            >
+              {c.name}
+            </a>
+          </li>
+        ))}
+        {!customers?.length && (
+          <li className="text-sm text-gray-500">No customers found</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function OrderDetailPage({ params }: Props) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: order } = await supabase
+    .from("orders")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+  const { data: items } = await supabase
+    .from("order_items")
+    .select("*")
+    .eq("order_id", params.id);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Order {params.id}</h1>
+      <p>Status: {order?.status}</p>
+      <p>Total: {order?.total}</p>
+      <ul className="space-y-4">
+        {items?.map((item) => (
+          <li key={item.id} className="border p-4 rounded">
+            <p className="text-sm">Part: {item.part_id}</p>
+            <p className="text-sm">Quantity: {item.quantity}</p>
+            <p className="text-sm">Line Total: {item.line_total}</p>
+          </li>
+        ))}
+        {!items?.length && <li className="text-sm text-gray-500">No items</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,0 +1,36 @@
+import { createClient } from "@/lib/supabase/server";
+import { requireAdmin } from "@/lib/auth";
+
+export default async function AdminOrdersPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: orders } = await supabase
+    .from("orders")
+    .select("id,status,total,created_at")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Orders</h1>
+      <ul className="space-y-2">
+        {orders?.map((o) => (
+          <li key={o.id} className="border p-4 rounded">
+            <a
+              href={`/admin/orders/${o.id}`}
+              className="text-blue-600 underline"
+            >
+              {o.id}
+            </a>
+            <p className="text-sm">Status: {o.status}</p>
+            <p className="text-sm">Total: {o.total}</p>
+          </li>
+        ))}
+        {!orders?.length && (
+          <li className="text-sm text-gray-500">No orders found</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/parts/page.tsx
+++ b/src/app/admin/parts/page.tsx
@@ -1,0 +1,28 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AdminPartsPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: parts } = await supabase
+    .from("parts")
+    .select("id,file_name,owner_id,created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">All Parts</h1>
+      <ul className="space-y-2">
+        {parts?.map((p) => (
+          <li key={p.id} className="border p-4 rounded">
+            <p className="text-sm">{p.file_name}</p>
+            <p className="text-xs text-gray-500">Owner: {p.owner_id}</p>
+          </li>
+        ))}
+        {!parts?.length && <li className="text-sm text-gray-500">No parts</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/payments/page.tsx
+++ b/src/app/admin/payments/page.tsx
@@ -1,0 +1,29 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function PaymentsAdminPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: payments } = await supabase
+    .from("payments")
+    .select("id,provider,amount,status,created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Payments</h1>
+      <ul className="space-y-2">
+        {payments?.map((p) => (
+          <li key={p.id} className="border p-4 rounded">
+            <p className="text-sm">{p.provider}</p>
+            <p className="text-sm">Amount: {p.amount}</p>
+            <p className="text-sm">Status: {p.status}</p>
+          </li>
+        ))}
+        {!payments?.length && <li className="text-sm text-gray-500">No payments</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -1,0 +1,130 @@
+import ExportPdfButton from "@/components/admin/ExportPdfButton";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function QuoteDetailPage({ params }: Props) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: quote } = await supabase
+    .from("quotes")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+  const { data: items } = await supabase
+    .from("quote_items")
+    .select("*")
+    .eq("quote_id", params.id);
+
+  async function updateItem(formData: FormData) {
+    "use server";
+    const itemId = formData.get("item_id") as string;
+    const quantity = Number(formData.get("quantity"));
+    const process_code = formData.get("process_code") as string;
+    const material_id = (formData.get("material_id") as string) || null;
+    const finish_id = (formData.get("finish_id") as string) || null;
+    const tolerance_id = (formData.get("tolerance_id") as string) || null;
+    const supabase = createClient();
+    await supabase
+      .from("quote_items")
+      .update({
+        quantity,
+        process_code,
+        material_id,
+        finish_id,
+        tolerance_id,
+      })
+      .eq("id", itemId);
+    await fetch(
+      `${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/api/quotes/reprice`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ quoteId: params.id }),
+      },
+    );
+  }
+
+  async function resendQuote() {
+    "use server";
+    const supabase = createClient();
+    await supabase.from("quotes").update({ status: "sent" }).eq("id", params.id);
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Quote {params.id}</h1>
+      <div className="flex space-x-4">
+        <form action={resendQuote}>
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Resend Link
+          </button>
+        </form>
+        <ExportPdfButton quoteId={params.id} />
+      </div>
+      <ul className="space-y-4">
+        {items?.map((item) => (
+          <li key={item.id} className="border p-4 rounded">
+            <form action={updateItem} className="space-y-2">
+              <input type="hidden" name="item_id" value={item.id} />
+              <div>
+                <label className="block text-sm">Process</label>
+                <input
+                  name="process_code"
+                  defaultValue={item.process_code ?? ""}
+                  className="border p-1 rounded w-full"
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Quantity</label>
+                <input
+                  name="quantity"
+                  type="number"
+                  min={1}
+                  defaultValue={item.quantity}
+                  className="border p-1 rounded w-full"
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Material ID</label>
+                <input
+                  name="material_id"
+                  defaultValue={item.material_id ?? ""}
+                  className="border p-1 rounded w-full"
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Finish ID</label>
+                <input
+                  name="finish_id"
+                  defaultValue={item.finish_id ?? ""}
+                  className="border p-1 rounded w-full"
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Tolerance ID</label>
+                <input
+                  name="tolerance_id"
+                  defaultValue={item.tolerance_id ?? ""}
+                  className="border p-1 rounded w-full"
+                />
+              </div>
+              <button
+                type="submit"
+                className="mt-2 px-3 py-1 bg-green-600 text-white rounded"
+              >
+                Update
+              </button>
+            </form>
+          </li>
+        ))}
+        {!items?.length && <li className="text-sm text-gray-500">No items</li>}
+      </ul>
+      <p className="text-sm">Total: {quote?.total}</p>
+    </div>
+  );
+}
+

--- a/src/app/admin/quotes/page.tsx
+++ b/src/app/admin/quotes/page.tsx
@@ -1,0 +1,36 @@
+import { createClient } from "@/lib/supabase/server";
+import { requireAdmin } from "@/lib/auth";
+
+export default async function AdminQuotesPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: quotes } = await supabase
+    .from("quotes")
+    .select("id,status,total,updated_at")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  return (
+    <div className="max-w-4xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Quotes</h1>
+      <ul className="space-y-2">
+        {quotes?.map((q) => (
+          <li key={q.id} className="border p-4 rounded">
+            <a
+              href={`/admin/quotes/${q.id}`}
+              className="text-blue-600 underline"
+            >
+              {q.id}
+            </a>
+            <p className="text-sm">Status: {q.status}</p>
+            <p className="text-sm">Total: {q.total}</p>
+          </li>
+        ))}
+        {!quotes?.length && (
+          <li className="text-sm text-gray-500">No quotes found</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,50 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function UsersAdminPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: users } = await supabase
+    .from("profiles")
+    .select("id,full_name,email,role")
+    .order("created_at", { ascending: false });
+
+  async function updateRole(formData: FormData) {
+    "use server";
+    const userId = formData.get("user_id") as string;
+    const role = formData.get("role") as string;
+    const supabase = createClient();
+    await supabase.from("profiles").update({ role }).eq("id", userId);
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Users</h1>
+      <ul className="space-y-4">
+        {users?.map((u) => (
+          <li key={u.id} className="border p-4 rounded">
+            <p className="text-sm font-semibold">{u.email}</p>
+            <p className="text-sm mb-2">Role: {u.role}</p>
+            <form action={updateRole} className="flex space-x-2">
+              <input type="hidden" name="user_id" value={u.id} />
+              <select name="role" defaultValue={u.role} className="border p-1 rounded">
+                <option value="admin">admin</option>
+                <option value="staff">staff</option>
+                <option value="customer">customer</option>
+                <option value="vendor">vendor</option>
+              </select>
+              <button
+                type="submit"
+                className="px-3 py-1 bg-blue-600 text-white rounded"
+              >
+                Save
+              </button>
+            </form>
+          </li>
+        ))}
+        {!users?.length && <li className="text-sm text-gray-500">No users</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/admin/vendors/[id]/page.tsx
+++ b/src/app/admin/vendors/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function VendorDetailPage({ params }: Props) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: vendor } = await supabase
+    .from("profiles")
+    .select("id,full_name,email,role")
+    .eq("id", params.id)
+    .single();
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Vendor {vendor?.email}</h1>
+      <p className="text-sm">Name: {vendor?.full_name}</p>
+      <p className="text-sm">Role: {vendor?.role}</p>
+      <div className="p-4 border rounded">
+        Assignment rules configuration coming soon.
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/admin/vendors/page.tsx
+++ b/src/app/admin/vendors/page.tsx
@@ -1,0 +1,54 @@
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function VendorsAdminPage() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data: vendors } = await supabase
+    .from("profiles")
+    .select("id,full_name,email")
+    .eq("role", "vendor")
+    .order("created_at", { ascending: false });
+
+  async function assignVendor(formData: FormData) {
+    "use server";
+    const userId = formData.get("user_id") as string;
+    const supabase = createClient();
+    await supabase.from("profiles").update({ role: "vendor" }).eq("id", userId);
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Vendors</h1>
+      <form action={assignVendor} className="flex space-x-2">
+        <input
+          name="user_id"
+          placeholder="User ID"
+          className="border p-1 rounded flex-1"
+        />
+        <button
+          type="submit"
+          className="px-4 py-1 bg-blue-600 text-white rounded"
+        >
+          Add Vendor
+        </button>
+      </form>
+      <ul className="space-y-4">
+        {vendors?.map((v) => (
+          <li key={v.id} className="border p-4 rounded">
+            <a
+              href={`/admin/vendors/${v.id}`}
+              className="text-blue-600 underline"
+            >
+              {v.email || v.full_name || v.id}
+            </a>
+          </li>
+        ))}
+        {!vendors?.length && (
+          <li className="text-sm text-gray-500">No vendors found</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/api/quotes/reprice/route.ts
+++ b/src/app/api/quotes/reprice/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { calculatePricing } from "@/lib/pricing";
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+  if (profile?.role !== "admin" && profile?.role !== "staff") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const quoteId = body?.quoteId as string | undefined;
+  if (!quoteId) {
+    return NextResponse.json({ error: "quoteId required" }, { status: 400 });
+  }
+
+  const { data: rateCard } = await supabase
+    .from("rate_cards")
+    .select("*")
+    .eq("is_active", true)
+    .limit(1)
+    .single();
+
+  const { data: items } = await supabase
+    .from("quote_items")
+    .select("*")
+    .eq("quote_id", quoteId);
+
+  if (!items || !items.length) {
+    return NextResponse.json({ error: "No items" }, { status: 400 });
+  }
+
+  let subtotal = 0;
+  let tax = 0;
+  let shipping = 0;
+  let total = 0;
+
+  for (const item of items) {
+    const [{ data: part }, { data: material }, { data: finish }, { data: tolerance }] =
+      await Promise.all([
+        supabase.from("parts").select("*").eq("id", item.part_id).single(),
+        supabase.from("materials").select("*").eq("id", item.material_id).single(),
+        item.finish_id
+          ? supabase.from("finishes").select("*").eq("id", item.finish_id).single()
+          : Promise.resolve({ data: null } as any),
+        item.tolerance_id
+          ? supabase.from("tolerances").select("*").eq("id", item.tolerance_id).single()
+          : Promise.resolve({ data: null } as any),
+      ]);
+
+    const geometry = {
+      volume_mm3: part?.volume_mm3 ?? 0,
+      surface_area_mm2: part?.surface_area_mm2 ?? 0,
+      bbox: part?.bbox ?? [0, 0, 0],
+      thickness_mm: part?.thickness_mm ?? undefined,
+      holes_count: part?.holes_count ?? undefined,
+      bends_count: part?.bends_count ?? undefined,
+      max_overhang_deg: part?.max_overhang_deg ?? undefined,
+    };
+
+    const leadTime = item.lead_time_days && item.lead_time_days <= 3 ? "expedite" : "standard";
+
+    const pricing = calculatePricing({
+      process: item.process_code as any,
+      quantity: item.quantity,
+      material: material!,
+      finish: finish || undefined,
+      tolerance: tolerance || undefined,
+      geometry,
+      lead_time: leadTime,
+      rate_card: rateCard || {},
+    });
+
+    await supabase
+      .from("quote_items")
+      .update({
+        unit_price: pricing.total / item.quantity,
+        line_total: pricing.total,
+        pricing_breakdown: pricing.breakdownJson,
+        lead_time_days: pricing.lead_time_days,
+      })
+      .eq("id", item.id);
+
+    subtotal += pricing.subtotal;
+    tax += pricing.tax;
+    shipping += pricing.shipping;
+    total += pricing.total;
+  }
+
+  await supabase
+    .from("quotes")
+    .update({ subtotal, tax, shipping, total })
+    .eq("id", quoteId);
+
+  return NextResponse.json({ subtotal, tax, shipping, total });
+}
+

--- a/src/components/admin/ExportPdfButton.tsx
+++ b/src/components/admin/ExportPdfButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface Props {
+  quoteId: string;
+}
+
+export default function ExportPdfButton({ quoteId }: Props) {
+  const handleClick = () => {
+    // Placeholder for actual PDF generation
+    alert(`PDF export for quote ${quoteId} is not implemented yet.`);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="px-4 py-2 bg-gray-200 rounded"
+    >
+      Export PDF
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin pages for quotes, orders, users, customers, parts, payments, abandoned records, and vendors
- enable quote editing with PDF export stub and server-side repricing API
- allow admins to change user roles and convert abandoned leads into customers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca473e6888322bd8fad4d97409716