### PR TITLE
feat: add machines and related policies

### DIFF
--- a/sql/migrations/015_machines.sql
+++ b/sql/migrations/015_machines.sql
@@ -1,0 +1,44 @@
+begin;
+create table if not exists public.machines (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  process_code text not null references public.processes(code),
+  axis_count int default 3,
+  envelope_mm jsonb, -- {x:..., y:..., z:...}
+  rate_per_min numeric not null,
+  setup_fee numeric default 0,
+  overhead_multiplier numeric default 1.0,
+  expedite_multiplier numeric default 1.2,
+  utilization_target numeric default 0.7,
+  margin_pct numeric default 0.15,
+  is_active boolean default true,
+  meta jsonb,
+  created_by uuid references public.profiles(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.machine_materials (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid references public.machines(id) on delete cascade,
+  material_id uuid references public.materials(id) on delete cascade,
+  material_rate_multiplier numeric default 1.0, -- extra penalty for hard-to-cut materials
+  unique (machine_id, material_id)
+);
+
+create table if not exists public.machine_finishes (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid references public.machines(id) on delete cascade,
+  finish_id uuid references public.finishes(id) on delete cascade,
+  finish_rate_multiplier numeric default 1.0,
+  unique (machine_id, finish_id)
+);
+
+-- geometry helpers already exist on parts, ensure indexes
+create index if not exists idx_parts_process on public.parts(process_code);
+create index if not exists idx_quote_items_quote on public.quote_items(quote_id);
+
+-- quotes: add machine selection
+alter table public.quote_items add column if not exists machine_id uuid references public.machines(id);
+
+commit;

--- a/sql/policies.sql
+++ b/sql/policies.sql
@@ -81,6 +81,24 @@ drop policy if exists rate_cards_admin_all on public.rate_cards;
 create policy rate_cards_admin_all on public.rate_cards
   for all using (public.is_admin()) with check (public.is_admin());
 
+-- Machines
+alter table public.machines enable row level security;
+drop policy if exists machines_admin_all on public.machines;
+create policy machines_admin_all on public.machines
+  for all using (public.is_admin()) with check (public.is_admin());
+
+-- Machine materials
+alter table public.machine_materials enable row level security;
+drop policy if exists machine_materials_admin_all on public.machine_materials;
+create policy machine_materials_admin_all on public.machine_materials
+  for all using (public.is_admin()) with check (public.is_admin());
+
+-- Machine finishes
+alter table public.machine_finishes enable row level security;
+drop policy if exists machine_finishes_admin_all on public.machine_finishes;
+create policy machine_finishes_admin_all on public.machine_finishes
+  for all using (public.is_admin()) with check (public.is_admin());
+
 -- Parts
 alter table public.parts enable row level security;
 drop policy if exists parts_owner_select on public.parts;


### PR DESCRIPTION
## Summary
- add machines, machine_materials, and machine_finishes tables with quote link
- restrict machines tables to admin/staff via RLS policies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `su postgres -c "psql -f sql/schema.sql"`
- `su postgres -c "psql -f sql/migrations/015_machines.sql"`
- `su postgres -c "psql -f sql/policies.sql"`
- `su appuser -c "psql -d postgres -c \"insert into public.machines(name, process_code, rate_per_min) values ('Machine C','proc1',3.0);\""`

------
https://chatgpt.com/codex/tasks/task_e_68acb31675a883229aaf97fbaabf1e81