### PR TITLE
feat(admin): add machine management

### DIFF
--- a/src/app/admin/machines/[id]/page.tsx
+++ b/src/app/admin/machines/[id]/page.tsx
@@ -1,0 +1,143 @@
+import DataTable from "@/components/admin/DataTable";
+import { requireAdmin } from "@/lib/auth";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/client";
+import { z } from "zod";
+import { useEffect, useState } from "react";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function MachineDetailPage({ params }: Props) {
+  await requireAdmin();
+  const supabase = createServerClient();
+  const { data: machine } = await supabase
+    .from("machines")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+  return <ClientPage machine={machine} />;
+}
+
+function ClientPage({ machine }: { machine: any }) {
+  "use client";
+
+  const [materials, setMaterials] = useState<any[]>([]);
+  const [finishes, setFinishes] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+      const [{ data: mats }, { data: fins }] = await Promise.all([
+        supabase
+          .from("materials")
+          .select("id,name")
+          .eq("is_active", true)
+          .eq("process_code", machine.process_code)
+          .order("name"),
+        supabase
+          .from("finishes")
+          .select("id,name")
+          .eq("is_active", true)
+          .eq("process_code", machine.process_code)
+          .order("name"),
+      ]);
+      setMaterials(mats || []);
+      setFinishes(fins || []);
+    };
+    load();
+  }, [machine.process_code]);
+
+  const materialSchema = z.object({
+    material_id: z.string().uuid(),
+    material_rate_multiplier: z.number().optional(),
+    is_active: z.boolean().optional(),
+  });
+
+  const materialColumns = [
+    {
+      accessorKey: "material_id",
+      header: "Material",
+      cell: ({ row }: any) => row.original.materials?.name || row.original.material_id,
+    },
+    { accessorKey: "material_rate_multiplier", header: "Multiplier" },
+  ];
+
+  const materialFields = [
+    {
+      name: "material_id",
+      label: "Material",
+      type: "select",
+      options: materials.map((m) => ({ value: m.id, label: m.name })),
+    },
+    {
+      name: "material_rate_multiplier",
+      label: "Rate Multiplier",
+      type: "number",
+    },
+    { name: "is_active", label: "Active", type: "checkbox" },
+  ];
+
+  const finishSchema = z.object({
+    finish_id: z.string().uuid(),
+    finish_rate_multiplier: z.number().optional(),
+    is_active: z.boolean().optional(),
+  });
+
+  const finishColumns = [
+    {
+      accessorKey: "finish_id",
+      header: "Finish",
+      cell: ({ row }: any) => row.original.finishes?.name || row.original.finish_id,
+    },
+    { accessorKey: "finish_rate_multiplier", header: "Multiplier" },
+  ];
+
+  const finishFields = [
+    {
+      name: "finish_id",
+      label: "Finish",
+      type: "select",
+      options: finishes.map((f) => ({ value: f.id, label: f.name })),
+    },
+    {
+      name: "finish_rate_multiplier",
+      label: "Rate Multiplier",
+      type: "number",
+    },
+    { name: "is_active", label: "Active", type: "checkbox" },
+  ];
+
+  return (
+    <div className="max-w-5xl mx-auto py-10 space-y-10">
+      <h1 className="text-2xl font-semibold mb-4">{machine.name}</h1>
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Materials</h2>
+        <DataTable
+          table="machine_materials"
+          columns={materialColumns}
+          schema={materialSchema}
+          fields={materialFields}
+          filterKey="materials.name"
+          select="id, material_id, material_rate_multiplier, is_active, materials(name)"
+          eqFilters={{ machine_id: machine.id }}
+          insertDefaults={{ machine_id: machine.id }}
+        />
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Finishes</h2>
+        <DataTable
+          table="machine_finishes"
+          columns={finishColumns}
+          schema={finishSchema}
+          fields={finishFields}
+          filterKey="finishes.name"
+          select="id, finish_id, finish_rate_multiplier, is_active, finishes(name)"
+          eqFilters={{ machine_id: machine.id }}
+          insertDefaults={{ machine_id: machine.id }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/machines/page.tsx
+++ b/src/app/admin/machines/page.tsx
@@ -1,0 +1,108 @@
+import DataTable from "@/components/admin/DataTable";
+import { requireAdmin } from "@/lib/auth";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/client";
+import { useEffect, useState } from "react";
+
+export default async function MachinesPage() {
+  await requireAdmin();
+  return <ClientPage />;
+}
+
+function ClientPage() {
+  "use client";
+
+  const [processes, setProcesses] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("processes")
+        .select("code,name")
+        .order("name");
+      setProcesses(data || []);
+    };
+    load();
+  }, []);
+
+  const schema = z.object({
+    name: z.string().min(1),
+    process_code: z.string().min(1),
+    axis_count: z.number().optional(),
+    envelope_mm_x: z.number().optional(),
+    envelope_mm_y: z.number().optional(),
+    envelope_mm_z: z.number().optional(),
+    rate_per_min: z.number().optional(),
+    setup_fee: z.number().optional(),
+    overhead_multiplier: z.number().optional(),
+    expedite_multiplier: z.number().optional(),
+    utilization_target: z.number().optional(),
+    margin_pct: z.number().optional(),
+    is_active: z.boolean().optional(),
+  });
+
+  const columns = [
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }: any) => (
+        <a
+          href={`/admin/machines/${row.original.id}`}
+          className="text-blue-600 underline"
+        >
+          {row.original.name}
+        </a>
+      ),
+    },
+    { accessorKey: "process_code", header: "Process" },
+    { accessorKey: "axis_count", header: "Axis" },
+    { accessorKey: "rate_per_min", header: "Rate/min" },
+  ];
+
+  const fields = [
+    { name: "name", label: "Name", type: "text" },
+    {
+      name: "process_code",
+      label: "Process",
+      type: "select",
+      options: processes.map((p) => ({ value: p.code, label: p.name })),
+    },
+    { name: "axis_count", label: "Axis Count", type: "number" },
+    { name: "envelope_mm_x", label: "Envelope X (mm)", type: "number" },
+    { name: "envelope_mm_y", label: "Envelope Y (mm)", type: "number" },
+    { name: "envelope_mm_z", label: "Envelope Z (mm)", type: "number" },
+    { name: "rate_per_min", label: "Rate/min", type: "number" },
+    { name: "setup_fee", label: "Setup Fee", type: "number" },
+    {
+      name: "overhead_multiplier",
+      label: "Overhead Multiplier",
+      type: "number",
+    },
+    {
+      name: "expedite_multiplier",
+      label: "Expedite Multiplier",
+      type: "number",
+    },
+    {
+      name: "utilization_target",
+      label: "Utilization Target",
+      type: "number",
+    },
+    { name: "margin_pct", label: "Margin %", type: "number" },
+    { name: "is_active", label: "Active", type: "checkbox" },
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-4">Machines</h1>
+      <DataTable
+        table="machines"
+        columns={columns}
+        schema={schema}
+        fields={fields}
+        filterKey="name"
+      />
+    </div>
+  );
+}

--- a/src/app/api/machines/[id]/finishes/route.ts
+++ b/src/app/api/machines/[id]/finishes/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const finishSchema = z.object({
+  finish_id: z.string().uuid(),
+  finish_rate_multiplier: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+const updateSchema = z.object({
+  id: z.string().uuid(),
+  finish_rate_multiplier: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_finishes")
+    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)")
+    .eq("machine_id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request, { params }: Params) {
+  await requireAdmin();
+  let body;
+  try {
+    body = finishSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_finishes")
+    .insert({ machine_id: params.id, ...body })
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  await requireAdmin();
+  let body;
+  try {
+    body = updateSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_finishes")
+    .update({
+      finish_rate_multiplier: body.finish_rate_multiplier,
+      is_active: body.is_active,
+    })
+    .eq("id", body.id)
+    .eq("machine_id", params.id)
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request, { params }: Params) {
+  await requireAdmin();
+  const body = await req.json().catch(() => null);
+  const id = body?.id as string | undefined;
+  if (!id) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("machine_finishes")
+    .delete()
+    .eq("id", id)
+    .eq("machine_id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const materialSchema = z.object({
+  material_id: z.string().uuid(),
+  material_rate_multiplier: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+const updateSchema = z.object({
+  id: z.string().uuid(),
+  material_rate_multiplier: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_materials")
+    .select("id, material_id, material_rate_multiplier, is_active, materials(name)")
+    .eq("machine_id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request, { params }: Params) {
+  await requireAdmin();
+  let body;
+  try {
+    body = materialSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_materials")
+    .insert({ machine_id: params.id, ...body })
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  await requireAdmin();
+  let body;
+  try {
+    body = updateSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_materials")
+    .update({
+      material_rate_multiplier: body.material_rate_multiplier,
+      is_active: body.is_active,
+    })
+    .eq("id", body.id)
+    .eq("machine_id", params.id)
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request, { params }: Params) {
+  await requireAdmin();
+  const body = await req.json().catch(() => null);
+  const id = body?.id as string | undefined;
+  if (!id) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("machine_materials")
+    .delete()
+    .eq("id", id)
+    .eq("machine_id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const machineSchema = z.object({
+  name: z.string().min(1),
+  process_code: z.string().min(1),
+  axis_count: z.number().optional(),
+  envelope_mm_x: z.number().optional(),
+  envelope_mm_y: z.number().optional(),
+  envelope_mm_z: z.number().optional(),
+  rate_per_min: z.number().optional(),
+  setup_fee: z.number().optional(),
+  overhead_multiplier: z.number().optional(),
+  expedite_multiplier: z.number().optional(),
+  utilization_target: z.number().optional(),
+  margin_pct: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machines")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  await requireAdmin();
+  let body;
+  try {
+    body = machineSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machines")
+    .update(body)
+    .eq("id", params.id)
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  await requireAdmin();
+  const supabase = createClient();
+  const { error } = await supabase.from("machines").delete().eq("id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/machines/route.ts
+++ b/src/app/api/machines/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const machineSchema = z.object({
+  name: z.string().min(1),
+  process_code: z.string().min(1),
+  axis_count: z.number().optional(),
+  envelope_mm_x: z.number().optional(),
+  envelope_mm_y: z.number().optional(),
+  envelope_mm_z: z.number().optional(),
+  rate_per_min: z.number().optional(),
+  setup_fee: z.number().optional(),
+  overhead_multiplier: z.number().optional(),
+  expedite_multiplier: z.number().optional(),
+  utilization_target: z.number().optional(),
+  margin_pct: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+export async function GET() {
+  await requireAdmin();
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machines")
+    .select("*")
+    .order("name");
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  await requireAdmin();
+  let body;
+  try {
+    body = machineSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machines")
+    .insert(body)
+    .select("*")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}

--- a/src/components/admin/ModalForm.tsx
+++ b/src/components/admin/ModalForm.tsx
@@ -7,7 +7,7 @@ import { ZodSchema } from "zod";
 export interface Field {
   name: string;
   label: string;
-  type: "text" | "number" | "select" | "checkbox";
+  type: "text" | "number" | "select" | "checkbox" | "hidden";
   options?: { value: string; label: string }[];
 }
 
@@ -65,9 +65,11 @@ export default function ModalForm({
       >
         {fields.map((field) => (
           <div key={field.name}>
-            <label className="block text-sm font-medium mb-1">
-              {field.label}
-            </label>
+            {field.type !== "hidden" && (
+              <label className="block text-sm font-medium mb-1">
+                {field.label}
+              </label>
+            )}
             {field.type === "select" && field.options ? (
               <select
                 {...register(field.name, { required: true })}
@@ -88,10 +90,12 @@ export default function ModalForm({
                 {...register(field.name, {
                   valueAsNumber: field.type === "number" ? true : undefined,
                 })}
-                className="border rounded p-2 w-full"
+                className={
+                  field.type === "hidden" ? undefined : "border rounded p-2 w-full"
+                }
               />
             )}
-            {errors[field.name] && (
+            {field.type !== "hidden" && errors[field.name] && (
               <p className="text-red-600 text-sm mt-1">
                 {(errors as any)[field.name]?.message as string}
               </p>


### PR DESCRIPTION
## Summary
- add admin CRUD UI for machines with detail pages for materials and finishes
- extend generic admin tables/forms for filtering and default values
- expose machine and attachment API routes with admin auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb31fe82c83228d93851edc1355bd