### PR TITLE
feat: add quote UX components

### DIFF
--- a/src/components/quotes/MarkQuotePanel.tsx
+++ b/src/components/quotes/MarkQuotePanel.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+interface MarkQuotePanelProps {
+  quoteId: string;
+  currentStatus: string;
+  allowedStatuses?: string[];
+  onStatusChange?: (newStatus: string) => void;
+}
+
+export default function MarkQuotePanel({
+  quoteId,
+  currentStatus,
+  allowedStatuses = ["estimate", "ordered", "cancelled"],
+  onStatusChange,
+}: MarkQuotePanelProps) {
+  const [status, setStatus] = useState(currentStatus);
+  const [note, setNote] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const updateStatus = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/quotes/${quoteId}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, note }),
+      });
+      if (res.ok) {
+        await fetch(`/api/quotes/${quoteId}/activities`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: note, type: `status:${status}` }),
+        });
+        onStatusChange?.(status);
+      } else {
+        console.error(await res.json());
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded space-y-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor="status" className="text-sm">Status</label>
+        <select
+          id="status"
+          className="border rounded p-1 text-sm"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          {allowedStatuses.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        className="w-full border rounded p-2 text-sm"
+        rows={3}
+        placeholder="Add a note"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <button
+        disabled={saving}
+        onClick={updateStatus}
+        className="px-3 py-1 bg-blue-600 text-white rounded text-sm disabled:opacity-50"
+      >
+        {saving ? "Saving..." : "Update Status"}
+      </button>
+    </div>
+  );
+}
+

--- a/src/components/quotes/MeasurementInfo.tsx
+++ b/src/components/quotes/MeasurementInfo.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+
+interface MeasurementInfoProps {
+  bbox: [number, number, number];
+  surface_area_mm2: number;
+  volume_mm3: number;
+  units: "mm" | "inch";
+  partId?: string;
+}
+
+export default function MeasurementInfo({
+  bbox,
+  surface_area_mm2,
+  volume_mm3,
+  units,
+  partId,
+}: MeasurementInfoProps) {
+  const factor = units === "inch" ? 25.4 : 1;
+  const displayBbox = bbox.map((d) => (d / factor).toFixed(2)).join(" × ");
+  const area = (surface_area_mm2 / (factor * factor)).toFixed(2);
+  const volume = (volume_mm3 / (factor * factor * factor)).toFixed(2);
+
+  return (
+    <div className="space-y-1 text-sm">
+      <div>Bounding box: {displayBbox} {units}</div>
+      <div>Surface area: {area} {units}²</div>
+      <div>Volume: {volume} {units}³</div>
+      {partId && (
+        <Link href={`/viewer/${partId}`} className="text-blue-600 hover:underline">
+          View 3D model
+        </Link>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/quotes/MultiPartMenu.tsx
+++ b/src/components/quotes/MultiPartMenu.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+import { Plus, Trash2 } from "lucide-react";
+
+interface Tier {
+  quantity: number;
+  price: number;
+}
+
+interface Part {
+  id: string;
+  name: string;
+  price?: number;
+  tiers?: Tier[];
+}
+
+interface MultiPartMenuProps {
+  parts: Part[];
+  currentPartId?: string;
+  onSelectPart?: (id: string) => void;
+  onAddPart?: () => void;
+  onRemovePart?: (id: string) => void;
+}
+
+export default function MultiPartMenu({
+  parts,
+  currentPartId,
+  onSelectPart,
+  onAddPart,
+  onRemovePart,
+}: MultiPartMenuProps) {
+  const selected = parts.find((p) => p.id === currentPartId);
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium">Parts</span>
+        {onAddPart && (
+          <button
+            onClick={onAddPart}
+            className="flex items-center text-sm text-blue-600"
+          >
+            <Plus className="w-4 h-4 mr-1" /> Add Part
+          </button>
+        )}
+      </div>
+      <ul className="space-y-1">
+        {parts.map((part) => (
+          <li
+            key={part.id}
+            className={`flex items-center justify-between p-2 rounded cursor-pointer ${
+              currentPartId === part.id ? "bg-gray-200" : "hover:bg-gray-100"
+            }`}
+            onClick={() => onSelectPart?.(part.id)}
+          >
+            <span>{part.name}</span>
+            <span className="flex items-center space-x-2">
+              {typeof part.price !== "undefined" && (
+                <span className="text-sm">${part.price.toFixed(2)}</span>
+              )}
+              {onRemovePart && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemovePart(part.id);
+                  }}
+                  className="text-red-600"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div className="mt-4 space-y-1 text-sm">
+          {typeof selected.price !== "undefined" && (
+            <div>Price: ${selected.price.toFixed(2)}</div>
+          )}
+          {selected.tiers && selected.tiers.length > 0 && (
+            <div>
+              <div className="font-medium">Quantity Tiers</div>
+              <ul className="list-disc ml-4">
+                {selected.tiers.map((t) => (
+                  <li key={t.quantity}>
+                    {t.quantity}+ : ${t.price.toFixed(2)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/quotes/QuoteHeader.tsx
+++ b/src/components/quotes/QuoteHeader.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+
+interface QuoteHeaderProps {
+  quote: {
+    id: string;
+    status: "estimate" | "ordered" | string;
+    name?: string | null;
+  };
+  viewerRole?: "customer" | "staff";
+}
+
+export default function QuoteHeader({ quote, viewerRole = "customer" }: QuoteHeaderProps) {
+  const title =
+    viewerRole === "staff"
+      ? `Quote #${quote.id}${quote.name ? ` – ${quote.name}` : ""}`
+      : quote.name || `Quote #${quote.id}`;
+  const statusLabel = quote.status === "ordered" ? "Ordered" : "Estimate";
+  const badgeColor =
+    quote.status === "ordered" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800";
+  return (
+    <header className="flex items-center justify-between mb-4">
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <span className={`px-2 py-1 rounded text-xs font-medium ${badgeColor}`}>{statusLabel}</span>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add QuoteHeader with role-based view and status badge
- enable admin quote status updates with notes and activity logging
- show geometry data with viewer link
- navigate and manage multiple quote parts with price tiers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad42df12f48322ac9a8d36bf26c366