### PR TITLE
feat: manage machines with materials and finishes

### DIFF
--- a/src/app/admin/machines/[id]/page.tsx
+++ b/src/app/admin/machines/[id]/page.tsx
@@ -142,27 +142,21 @@ function ClientPage({ machine }: { machine: any }) {
       <div>
         <h2 className="text-xl font-semibold mb-4">Materials</h2>
         <DataTable
-          table="machine_materials"
+          endpoint={`/api/machines/${machine.id}/materials`}
+          idInQuery
           columns={materialColumns}
           schema={materialSchema}
           fields={materialFields}
-          filterKey="materials.name"
-          select="id, material_id, material_rate_multiplier, is_active, materials(name)"
-          eqFilters={{ machine_id: machine.id }}
-          insertDefaults={{ machine_id: machine.id }}
         />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-4">Finishes</h2>
         <DataTable
-          table="machine_finishes"
+          endpoint={`/api/machines/${machine.id}/finishes`}
+          idInQuery
           columns={finishColumns}
           schema={finishSchema}
           fields={finishFields}
-          filterKey="finishes.name"
-          select="id, finish_id, finish_rate_multiplier, is_active, finishes(name)"
-          eqFilters={{ machine_id: machine.id }}
-          insertDefaults={{ machine_id: machine.id }}
         />
       </div>
       <div>

--- a/src/app/admin/machines/page.tsx
+++ b/src/app/admin/machines/page.tsx
@@ -100,7 +100,7 @@ function ClientPage() {
     <div className="max-w-6xl mx-auto py-10">
       <h1 className="text-2xl font-semibold mb-4">Machines</h1>
       <DataTable
-        table="machines"
+        endpoint="/api/machines"
         columns={columns}
         schema={schema}
         fields={fields}

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -3,14 +3,8 @@ import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 
-const materialSchema = z.object({
+const schema = z.object({
   material_id: z.string().uuid(),
-  material_rate_multiplier: z.number().optional(),
-  is_active: z.boolean().optional(),
-});
-
-const updateSchema = z.object({
-  id: z.string().uuid(),
   material_rate_multiplier: z.number().optional(),
   is_active: z.boolean().optional(),
 });
@@ -19,24 +13,33 @@ interface Params {
   params: { id: string };
 }
 
-export async function GET(_req: Request, { params }: Params) {
+export async function GET(req: Request, { params }: Params) {
   await requireAdmin();
+  const { searchParams } = new URL(req.url);
+  const search = searchParams.get("search") || "";
+  const page = parseInt(searchParams.get("page") || "0", 10);
+  const PAGE_SIZE = 10;
   const supabase = createClient();
-  const { data, error } = await supabase
+  const { data, count, error } = await supabase
     .from("machine_materials")
-    .select("id, material_id, material_rate_multiplier, is_active, materials(name)")
-    .eq("machine_id", params.id);
+    .select("id, material_id, material_rate_multiplier, is_active, materials(name)", {
+      count: "exact",
+    })
+    .eq("machine_id", params.id)
+    .order("materials.name")
+    .ilike("materials.name", `%${search}%`)
+    .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  return NextResponse.json(data);
+  return NextResponse.json({ data, count });
 }
 
 export async function POST(req: Request, { params }: Params) {
   await requireAdmin();
   let body;
   try {
-    body = materialSchema.parse(await req.json());
+    body = schema.parse(await req.json());
   } catch (err: any) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
@@ -44,8 +47,8 @@ export async function POST(req: Request, { params }: Params) {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("machine_materials")
-    .insert({ machine_id: params.id, ...body })
-    .select("*")
+    .insert({ ...body, machine_id: params.id })
+    .select("id, material_id, material_rate_multiplier, is_active, materials(name)")
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -55,9 +58,14 @@ export async function POST(req: Request, { params }: Params) {
 
 export async function PUT(req: Request, { params }: Params) {
   await requireAdmin();
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  if (!id) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
   let body;
   try {
-    body = updateSchema.parse(await req.json());
+    body = schema.partial().parse(await req.json());
   } catch (err: any) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
@@ -65,13 +73,10 @@ export async function PUT(req: Request, { params }: Params) {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("machine_materials")
-    .update({
-      material_rate_multiplier: body.material_rate_multiplier,
-      is_active: body.is_active,
-    })
-    .eq("id", body.id)
+    .update(body)
+    .eq("id", id)
     .eq("machine_id", params.id)
-    .select("*")
+    .select("id, material_id, material_rate_multiplier, is_active, materials(name)")
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -81,10 +86,10 @@ export async function PUT(req: Request, { params }: Params) {
 
 export async function DELETE(req: Request, { params }: Params) {
   await requireAdmin();
-  const body = await req.json().catch(() => null);
-  const id = body?.id as string | undefined;
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
   if (!id) {
-    return NextResponse.json({ error: "id required" }, { status: 400 });
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
   const supabase = createClient();
   const { error } = await supabase
@@ -97,3 +102,4 @@ export async function DELETE(req: Request, { params }: Params) {
   }
   return NextResponse.json({ ok: true });
 }
+

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -41,7 +41,7 @@ export async function PUT(req: Request, { params }: Params) {
   await requireAdmin();
   let body;
   try {
-    body = machineSchema.parse(await req.json());
+    body = machineSchema.partial().parse(await req.json());
   } catch (err: any) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });

--- a/src/components/admin/ModalForm.tsx
+++ b/src/components/admin/ModalForm.tsx
@@ -63,7 +63,7 @@ export default function ModalForm({
         onSubmit={submit}
         className="bg-white rounded-md p-6 w-full max-w-md space-y-4"
       >
-        {fields.map((field) => (
+        {fields.map((field, idx) => (
           <div key={field.name}>
             {field.type !== "hidden" && (
               <label className="block text-sm font-medium mb-1">
@@ -93,6 +93,7 @@ export default function ModalForm({
                 className={
                   field.type === "hidden" ? undefined : "border rounded p-2 w-full"
                 }
+                autoFocus={idx === 0}
               />
             )}
             {field.type !== "hidden" && errors[field.name] && (


### PR DESCRIPTION
## Summary
- add admin UI for machine CRUD backed by API endpoints
- allow attaching materials and finishes with rate multipliers
- support generic DataTable fetching via API with pagination and active toggles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad4861ab8c832282c38ad6f60712ec