### PR TITLE
feat: preload instant quotes with automatic geometry and pricing

### DIFF
--- a/src/app/(customer)/instant-quote/page.tsx
+++ b/src/app/(customer)/instant-quote/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import InstantQuoteForm from "@/components/quotes/InstantQuoteForm";
 
@@ -13,6 +13,22 @@ export default function InstantQuotePage({ searchParams }: Props) {
   const quoteId = typeof searchParams.quoteId === "string" ? searchParams.quoteId : undefined;
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [geomReady, setGeomReady] = useState(!partId);
+
+  useEffect(() => {
+    if (!partId) return;
+    (async () => {
+      try {
+        await fetch("/api/parts/geometry", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ part_id: partId }),
+        });
+      } finally {
+        setGeomReady(true);
+      }
+    })();
+  }, [partId]);
 
   const requestQuote = async () => {
     if (!quoteId) return;
@@ -35,7 +51,11 @@ export default function InstantQuotePage({ searchParams }: Props) {
     <div className="max-w-2xl mx-auto py-10">
       <h1 className="text-2xl font-semibold mb-6">Instant Quote</h1>
       {partId ? (
-        <InstantQuoteForm partId={partId} />
+        geomReady ? (
+          <InstantQuoteForm partId={partId} />
+        ) : (
+          <p className="text-sm text-gray-500">Analyzing geometry...</p>
+        )
       ) : (
         <p className="text-sm text-gray-500">No part selected.</p>
       )}

--- a/src/components/quotes/InstantQuoteForm.tsx
+++ b/src/components/quotes/InstantQuoteForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { calculatePricing, PricingResult } from "@/lib/pricing";
 import { Geometry } from "@/lib/validators/pricing";
+import { createClient } from "@/lib/supabase/client";
 
 const formSchema = z.object({
   material_id: z.string(),
@@ -19,38 +20,84 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 interface Props {
-  part: any;
-  materials: any[];
-  finishes: any[];
-  tolerances: any[];
-  machines: any[];
-  rateCard: any;
+  partId: string;
 }
 
-export default function InstantQuoteForm({
-  part,
-  materials,
-  finishes,
-  tolerances,
-  machines,
-  rateCard,
-}: Props) {
+export default function InstantQuoteForm({ partId }: Props) {
   const router = useRouter();
-  const {
-    register,
-    handleSubmit,
-    watch,
-    setValue,
-  } = useForm<FormValues>({
-    defaultValues: {
-      material_id: materials[0]?.id,
-      quantity: 1,
-      units: part.units || "mm",
-      lead_time: "standard",
-    },
+  const [part, setPart] = useState<any | null>(null);
+  const [materials, setMaterials] = useState<any[]>([]);
+  const [finishes, setFinishes] = useState<any[]>([]);
+  const [tolerances, setTolerances] = useState<any[]>([]);
+  const [machines, setMachines] = useState<any[]>([]);
+  const [rateCard, setRateCard] = useState<any | null>(null);
+  const [price, setPrice] = useState<PricingResult | null>(null);
+
+  const { register, handleSubmit, watch, setValue } = useForm<FormValues>({
+    defaultValues: { quantity: 1, units: "mm", lead_time: "standard" },
   });
 
-  const [price, setPrice] = useState<PricingResult | null>(null);
+  useEffect(() => {
+    async function load() {
+      const supabase = createClient();
+      const { data: partData } = await supabase
+        .from("parts")
+        .select("*")
+        .eq("id", partId)
+        .single();
+      if (!partData) return;
+
+      // compute geometry if missing
+      if (
+        partData.volume_mm3 === null ||
+        partData.surface_area_mm2 === null ||
+        partData.bbox === null
+      ) {
+        const res = await fetch("/api/parts/geometry", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ part_id: partId }),
+        });
+        if (res.ok) {
+          const g = await res.json();
+          partData.volume_mm3 = g.geometry.volume_mm3;
+          partData.surface_area_mm2 = g.geometry.surface_area_mm2;
+          partData.bbox = g.geometry.bbox;
+        }
+      }
+
+      const [materialsRes, finishesRes, tolerancesRes, machinesRes, rateCardRes] =
+        await Promise.all([
+          supabase.from("materials").select("*").eq("is_active", true),
+          supabase.from("finishes").select("*").eq("is_active", true),
+          supabase.from("tolerances").select("*").eq("is_active", true),
+          supabase
+            .from("machines")
+            .select("*")
+            .eq("process_code", partData.process_code)
+            .eq("is_active", true),
+          supabase
+            .from("rate_cards")
+            .select("*")
+            .eq("is_active", true)
+            .limit(1)
+            .single(),
+        ]);
+
+      setPart(partData);
+      setMaterials(materialsRes.data ?? []);
+      setFinishes(finishesRes.data ?? []);
+      setTolerances(tolerancesRes.data ?? []);
+      setMachines(machinesRes.data ?? []);
+      setRateCard(rateCardRes.data ?? null);
+
+      if (materialsRes.data && materialsRes.data[0]) {
+        setValue("material_id", materialsRes.data[0].id);
+      }
+      setValue("units", partData.units || "mm");
+    }
+    load();
+  }, [partId, setValue]);
 
   const materialId = watch("material_id");
   const finishId = watch("finish_id");
@@ -59,6 +106,7 @@ export default function InstantQuoteForm({
   const leadTime = watch("lead_time");
 
   useEffect(() => {
+    if (!part || !rateCard) return;
     const material = materials.find((m) => m.id === materialId);
     if (!material) return;
     const finish = finishes.find((f) => f.id === finishId);
@@ -73,10 +121,15 @@ export default function InstantQuoteForm({
       .filter((m) => {
         if (!m.envelope_mm) return true;
         const { x, y, z } = m.envelope_mm;
-        return bbox[0] <= (x ?? Infinity) && bbox[1] <= (y ?? Infinity) && bbox[2] <= (z ?? Infinity);
+        return (
+          bbox[0] <= (x ?? Infinity) &&
+          bbox[1] <= (y ?? Infinity) &&
+          bbox[2] <= (z ?? Infinity)
+        );
       })
       .sort((a, b) => (a.rate_per_min ?? 0) - (b.rate_per_min ?? 0))[0];
-    const rc = { ...rateCard };
+
+    const rc = { ...(rateCard || {}) } as any;
     if (machine) {
       switch (part.process_code) {
         case "cnc_milling":
@@ -124,20 +177,18 @@ export default function InstantQuoteForm({
     rateCard,
   ]);
 
-  useEffect(() => {
-    // ensure defaults set after materials load
-    if (!materialId && materials[0]) {
-      setValue("material_id", materials[0].id);
-    }
-  }, [materials, materialId, setValue]);
-
   const onSubmit = handleSubmit(async (values) => {
+    if (!part) return;
     try {
       const parsed = formSchema.parse(values);
       const res = await fetch("/api/quotes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...parsed, partId: part.id, process_code: part.process_code }),
+        body: JSON.stringify({
+          ...parsed,
+          partId: part.id,
+          process_code: part.process_code,
+        }),
       });
       if (res.ok) {
         const data = await res.json();
@@ -150,17 +201,26 @@ export default function InstantQuoteForm({
     }
   });
 
+  if (!part) {
+    return <p className="text-sm text-gray-500">Loading...</p>;
+  }
+
   return (
     <form onSubmit={onSubmit} className="space-y-4">
       {price && (
         <div className="p-4 bg-gray-100 rounded">
-          <p className="text-lg font-medium">Estimated Price: ${price.total.toFixed(2)}</p>
+          <p className="text-lg font-medium">
+            Estimated Price: ${price.total.toFixed(2)}
+          </p>
         </div>
       )}
 
       <div>
         <label className="block text-sm font-medium mb-1">Material</label>
-        <select {...register("material_id", { required: true })} className="w-full border rounded p-2">
+        <select
+          {...register("material_id", { required: true })}
+          className="w-full border rounded p-2"
+        >
           {materials.map((m) => (
             <option key={m.id} value={m.id}>
               {m.name}
@@ -171,7 +231,10 @@ export default function InstantQuoteForm({
 
       <div>
         <label className="block text-sm font-medium mb-1">Finish</label>
-        <select {...register("finish_id")} className="w-full border rounded p-2">
+        <select
+          {...register("finish_id")}
+          className="w-full border rounded p-2"
+        >
           <option value="">None</option>
           {finishes.map((f) => (
             <option key={f.id} value={f.id}>
@@ -183,7 +246,10 @@ export default function InstantQuoteForm({
 
       <div>
         <label className="block text-sm font-medium mb-1">Tolerance</label>
-        <select {...register("tolerance_id")} className="w-full border rounded p-2">
+        <select
+          {...register("tolerance_id")}
+          className="w-full border rounded p-2"
+        >
           <option value="">Standard</option>
           {tolerances.map((t) => (
             <option key={t.id} value={t.id}>
@@ -196,7 +262,10 @@ export default function InstantQuoteForm({
       <div className="flex space-x-4">
         <div className="flex-1">
           <label className="block text-sm font-medium mb-1">Quantity</label>
-          <select {...register("quantity", { valueAsNumber: true })} className="w-full border rounded p-2">
+          <select
+            {...register("quantity", { valueAsNumber: true })}
+            className="w-full border rounded p-2"
+          >
             {[1, 2, 5, 10, 25, 50, 100].map((q) => (
               <option key={q} value={q}>
                 {q}
@@ -215,7 +284,10 @@ export default function InstantQuoteForm({
 
       <div>
         <label className="block text-sm font-medium mb-1">Lead time</label>
-        <select {...register("lead_time")} className="w-full border rounded p-2">
+        <select
+          {...register("lead_time")}
+          className="w-full border rounded p-2"
+        >
           <option value="standard">Standard</option>
           <option value="expedite">Expedite</option>
         </select>


### PR DESCRIPTION
## Summary
- compute and store part geometry for STL uploads with placeholders for STEP/IGES
- ensure Instant Quote page computes geometry before showing form
- auto-fetch catalogs and machines to immediately price parts on Instant Quote

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: You're importing a component that needs useState. It only works in a Client Component but none of its parents are marked with "use client".)*

------
https://chatgpt.com/codex/tasks/task_e_68ad48766cc88322b2088301ecabc664