### PR TITLE
feat: refine quote detail components

### DIFF
--- a/src/components/quotes/MarkQuotePanel.tsx
+++ b/src/components/quotes/MarkQuotePanel.tsx
@@ -7,6 +7,8 @@ interface MarkQuotePanelProps {
   currentStatus: string;
   allowedStatuses?: string[];
   onStatusChange?: (newStatus: string) => void;
+  /** callback when an activity has been recorded */
+  onActivityAdded?: (activity: any) => void;
 }
 
 export default function MarkQuotePanel({
@@ -14,6 +16,7 @@ export default function MarkQuotePanel({
   currentStatus,
   allowedStatuses = ["estimate", "ordered", "cancelled"],
   onStatusChange,
+  onActivityAdded,
 }: MarkQuotePanelProps) {
   const [status, setStatus] = useState(currentStatus);
   const [note, setNote] = useState("");
@@ -28,12 +31,17 @@ export default function MarkQuotePanel({
         body: JSON.stringify({ status, note }),
       });
       if (res.ok) {
-        await fetch(`/api/quotes/${quoteId}/activities`, {
+        const activityRes = await fetch(`/api/quotes/${quoteId}/activities`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ message: note, type: `status:${status}` }),
         });
+        if (activityRes.ok) {
+          const activity = await activityRes.json();
+          onActivityAdded?.(activity);
+        }
         onStatusChange?.(status);
+        setNote("");
       } else {
         console.error(await res.json());
       }

--- a/src/components/quotes/MeasurementInfo.tsx
+++ b/src/components/quotes/MeasurementInfo.tsx
@@ -18,17 +18,23 @@ export default function MeasurementInfo({
   partId,
 }: MeasurementInfoProps) {
   const factor = units === "inch" ? 25.4 : 1;
-  const displayBbox = bbox.map((d) => (d / factor).toFixed(2)).join(" × ");
+  const [lx, ly, lz] = bbox.map((d) => (d / factor).toFixed(2));
   const area = (surface_area_mm2 / (factor * factor)).toFixed(2);
   const volume = (volume_mm3 / (factor * factor * factor)).toFixed(2);
 
   return (
     <div className="space-y-1 text-sm">
-      <div>Bounding box: {displayBbox} {units}</div>
+      <div>
+        Bounding box: {lx} × {ly} × {lz} {units}
+      </div>
       <div>Surface area: {area} {units}²</div>
       <div>Volume: {volume} {units}³</div>
       {partId && (
-        <Link href={`/viewer/${partId}`} className="text-blue-600 hover:underline">
+        <Link
+          href={`/viewer/${partId}`}
+          className="text-blue-600 hover:underline"
+          title="Open in 3D viewer"
+        >
           View 3D model
         </Link>
       )}

--- a/src/components/quotes/MultiPartMenu.tsx
+++ b/src/components/quotes/MultiPartMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 
 interface Tier {
@@ -30,7 +30,19 @@ export default function MultiPartMenu({
   onAddPart,
   onRemovePart,
 }: MultiPartMenuProps) {
-  const selected = parts.find((p) => p.id === currentPartId);
+  const [selectedId, setSelectedId] = useState<string | undefined>(currentPartId);
+
+  useEffect(() => {
+    setSelectedId(currentPartId);
+  }, [currentPartId]);
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id);
+    onSelectPart?.(id);
+  };
+
+  const selected = parts.find((p) => p.id === selectedId);
+
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
@@ -49,9 +61,9 @@ export default function MultiPartMenu({
           <li
             key={part.id}
             className={`flex items-center justify-between p-2 rounded cursor-pointer ${
-              currentPartId === part.id ? "bg-gray-200" : "hover:bg-gray-100"
+              selectedId === part.id ? "bg-gray-200" : "hover:bg-gray-100"
             }`}
-            onClick={() => onSelectPart?.(part.id)}
+            onClick={() => handleSelect(part.id)}
           >
             <span>{part.name}</span>
             <span className="flex items-center space-x-2">

--- a/src/components/quotes/QuoteHeader.tsx
+++ b/src/components/quotes/QuoteHeader.tsx
@@ -9,9 +9,21 @@ interface QuoteHeaderProps {
     name?: string | null;
   };
   viewerRole?: "customer" | "staff";
+  /** action when user wants to share the quote */
+  onShare?: () => void;
+  /** action when staff wants to update quote status */
+  onMark?: () => void;
+  /** action for customers to place an order */
+  onOrder?: () => void;
 }
 
-export default function QuoteHeader({ quote, viewerRole = "customer" }: QuoteHeaderProps) {
+export default function QuoteHeader({
+  quote,
+  viewerRole = "customer",
+  onShare,
+  onMark,
+  onOrder,
+}: QuoteHeaderProps) {
   const title =
     viewerRole === "staff"
       ? `Quote #${quote.id}${quote.name ? ` – ${quote.name}` : ""}`
@@ -20,9 +32,40 @@ export default function QuoteHeader({ quote, viewerRole = "customer" }: QuoteHea
   const badgeColor =
     quote.status === "ordered" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800";
   return (
-    <header className="flex items-center justify-between mb-4">
-      <h1 className="text-xl font-semibold">{title}</h1>
-      <span className={`px-2 py-1 rounded text-xs font-medium ${badgeColor}`}>{statusLabel}</span>
+    <header className="flex items-start justify-between mb-4 gap-2">
+      <div className="flex items-center gap-2">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        <span className={`px-2 py-1 rounded text-xs font-medium ${badgeColor}`}>{statusLabel}</span>
+      </div>
+      <div className="flex gap-2">
+        {viewerRole === "staff" && onMark && (
+          <button
+            type="button"
+            onClick={onMark}
+            className="px-3 py-1 text-sm border rounded"
+          >
+            Mark Quote
+          </button>
+        )}
+        {viewerRole === "customer" && quote.status === "estimate" && onOrder && (
+          <button
+            type="button"
+            onClick={onOrder}
+            className="px-3 py-1 text-sm border rounded"
+          >
+            Place Order
+          </button>
+        )}
+        {onShare && (
+          <button
+            type="button"
+            onClick={onShare}
+            className="px-3 py-1 text-sm border rounded"
+          >
+            Share
+          </button>
+        )}
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- enhance QuoteHeader with status badge and role-specific actions
- support admin status updates with activity logging in MarkQuotePanel
- display measurement stats and viewer link via MeasurementInfo
- enable part switching with dynamic pricing in MultiPartMenu

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad547ddfa88322b1bc4d6b760184e2