### PR TITLE
Add STL parser with units handling and geometry API

### DIFF
--- a/src/app/api/parts/geometry/stl/route.ts
+++ b/src/app/api/parts/geometry/stl/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@/lib/supabase/server';
+import { parseSTL } from '@/lib/geometry/stl';
+import { stlGeometrySchema } from '@/lib/validators/geometry';
+
+const MAX_FILE_SIZE = 150 * 1024 * 1024; // 150MB
+const ALLOWED_TYPES = ['application/octet-stream', 'model/stl'];
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: z.infer<typeof stlGeometrySchema>;
+  try {
+    body = stlGeometrySchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? 'Invalid request';
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const { partId, fileUrl, uploadId, unitsHint } = body;
+
+  const { data: part, error: partErr } = await supabase
+    .from('parts')
+    .select('*')
+    .eq('id', partId)
+    .eq('owner_id', user.id)
+    .single();
+  if (partErr || !part) {
+    return NextResponse.json({ error: 'Part not found' }, { status: 404 });
+  }
+
+  const path = fileUrl || uploadId || part.file_url;
+  if (!path) {
+    return NextResponse.json({ error: 'File path missing' }, { status: 400 });
+  }
+
+  const { data: signed, error: signErr } = await supabase.storage
+    .from('parts')
+    .createSignedUrl(path, 60);
+  if (signErr || !signed?.signedUrl) {
+    return NextResponse.json({ error: 'Failed to create signed URL' }, { status: 500 });
+  }
+
+  const resp = await fetch(signed.signedUrl);
+  if (!resp.ok) {
+    return NextResponse.json({ error: 'Failed to download file' }, { status: 400 });
+  }
+  const size = Number(resp.headers.get('content-length') || '0');
+  if (size > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: 'File too large' }, { status: 400 });
+  }
+  const type = resp.headers.get('content-type')?.split(';')[0].toLowerCase();
+  if (type && !ALLOWED_TYPES.includes(type)) {
+    return NextResponse.json({ error: 'Invalid content type' }, { status: 400 });
+  }
+
+  const arrayBuffer = await resp.arrayBuffer();
+  let geom;
+  try {
+    geom = parseSTL(arrayBuffer, { unitsHint });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to parse STL' }, { status: 400 });
+  }
+
+  const bboxSize: [number, number, number] = [
+    geom.bbox.max[0] - geom.bbox.min[0],
+    geom.bbox.max[1] - geom.bbox.min[1],
+    geom.bbox.max[2] - geom.bbox.min[2],
+  ];
+
+  const { error: updErr } = await supabase
+    .from('parts')
+    .update({
+      bbox: bboxSize,
+      surface_area_mm2: geom.surfaceArea_mm2,
+      volume_mm3: geom.volume_mm3,
+      units: geom.units,
+    })
+    .eq('id', partId);
+  if (updErr) {
+    return NextResponse.json({ error: 'Failed to persist geometry' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    geometry: {
+      bbox: bboxSize,
+      surface_area_mm2: geom.surfaceArea_mm2,
+      volume_mm3: geom.volume_mm3,
+      units: geom.units,
+    },
+  });
+}

--- a/src/lib/geometry/stl.ts
+++ b/src/lib/geometry/stl.ts
@@ -1,0 +1,146 @@
+import { convertToMM, inferUnits, Units } from './units';
+
+export interface ParsedSTL {
+  triangles: number[][][];
+  bbox: { min: [number, number, number]; max: [number, number, number] };
+  surfaceArea_mm2: number;
+  volume_mm3: number;
+  units: Units;
+  scaleToMM: (v: [number, number, number]) => [number, number, number];
+}
+
+function isBinarySTL(buf: Buffer): boolean {
+  if (buf.length < 84) return false;
+  const header = buf.slice(0, 80).toString('utf-8');
+  const solid = header.trim().startsWith('solid');
+  const triCount = buf.readUInt32LE(80);
+  const expectedSize = 84 + triCount * 50;
+  if (expectedSize === buf.length) return true;
+  return !solid;
+}
+
+export function parseSTL(
+  input: ArrayBuffer | Buffer,
+  opts?: { unitsHint?: Units },
+): ParsedSTL {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  const triangles: number[][][] = [];
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity,
+    surface = 0,
+    volume = 0;
+
+  const addTriangle = (
+    v1: [number, number, number],
+    v2: [number, number, number],
+    v3: [number, number, number],
+  ) => {
+    triangles.push([v1, v2, v3]);
+    const xs = [v1[0], v2[0], v3[0]];
+    const ys = [v1[1], v2[1], v3[1]];
+    const zs = [v1[2], v2[2], v3[2]];
+    minX = Math.min(minX, ...xs);
+    minY = Math.min(minY, ...ys);
+    minZ = Math.min(minZ, ...zs);
+    maxX = Math.max(maxX, ...xs);
+    maxY = Math.max(maxY, ...ys);
+    maxZ = Math.max(maxZ, ...zs);
+
+    const ab = [v2[0] - v1[0], v2[1] - v1[1], v2[2] - v1[2]];
+    const ac = [v3[0] - v1[0], v3[1] - v1[1], v3[2] - v1[2]];
+    const cross = [
+      ab[1] * ac[2] - ab[2] * ac[1],
+      ab[2] * ac[0] - ab[0] * ac[2],
+      ab[0] * ac[1] - ab[1] * ac[0],
+    ];
+    const area = 0.5 * Math.hypot(cross[0], cross[1], cross[2]);
+    surface += area;
+    volume += (v1[0] * cross[0] + v1[1] * cross[1] + v1[2] * cross[2]) / 6;
+  };
+
+  if (isBinarySTL(buf)) {
+    const triCount = buf.readUInt32LE(80);
+    let offset = 84;
+    for (let i = 0; i < triCount; i++) {
+      offset += 12; // skip normal
+      const v1: [number, number, number] = [
+        buf.readFloatLE(offset),
+        buf.readFloatLE(offset + 4),
+        buf.readFloatLE(offset + 8),
+      ];
+      offset += 12;
+      const v2: [number, number, number] = [
+        buf.readFloatLE(offset),
+        buf.readFloatLE(offset + 4),
+        buf.readFloatLE(offset + 8),
+      ];
+      offset += 12;
+      const v3: [number, number, number] = [
+        buf.readFloatLE(offset),
+        buf.readFloatLE(offset + 4),
+        buf.readFloatLE(offset + 8),
+      ];
+      offset += 12;
+      offset += 2; // attribute byte count
+      addTriangle(v1, v2, v3);
+    }
+  } else {
+    const text = buf.toString('utf-8');
+    const facetRegex = /facet[\s\S]*?endfacet/g;
+    let match: RegExpExecArray | null;
+    while ((match = facetRegex.exec(text))) {
+      const verts: [number, number, number][] = [];
+      const vertexRegex = /vertex\s+([\-+eE0-9\.]+)\s+([\-+eE0-9\.]+)\s+([\-+eE0-9\.]+)/g;
+      let vMatch: RegExpExecArray | null;
+      while ((vMatch = vertexRegex.exec(match[0]))) {
+        verts.push([
+          parseFloat(vMatch[1]),
+          parseFloat(vMatch[2]),
+          parseFloat(vMatch[3]),
+        ]);
+      }
+      if (verts.length === 3) {
+        addTriangle(verts[0], verts[1], verts[2]);
+      }
+    }
+  }
+
+  const bboxMin: [number, number, number] = [minX, minY, minZ];
+  const bboxMax: [number, number, number] = [maxX, maxY, maxZ];
+  const diag = Math.sqrt(
+    (maxX - minX) ** 2 + (maxY - minY) ** 2 + (maxZ - minZ) ** 2,
+  );
+  const units = inferUnits(diag, opts?.unitsHint);
+  const scale = convertToMM(1, units);
+  const bbox = {
+    min: bboxMin.map((v) => convertToMM(v, units)) as [
+      number,
+      number,
+      number,
+    ],
+    max: bboxMax.map((v) => convertToMM(v, units)) as [
+      number,
+      number,
+      number,
+    ],
+  };
+  const surfaceArea_mm2 = surface * scale * scale;
+  const volume_mm3 = Math.abs(volume) * scale * scale * scale;
+
+  return {
+    triangles,
+    bbox,
+    surfaceArea_mm2,
+    volume_mm3,
+    units,
+    scaleToMM: (v: [number, number, number]) => [
+      convertToMM(v[0], units),
+      convertToMM(v[1], units),
+      convertToMM(v[2], units),
+    ],
+  };
+}

--- a/src/lib/geometry/units.ts
+++ b/src/lib/geometry/units.ts
@@ -1,0 +1,36 @@
+export type Units = 'mm' | 'inch' | 'm';
+
+/** Convert a value from given units to millimeters */
+export function convertToMM(value: number, from: Units): number {
+  switch (from) {
+    case 'inch':
+      return value * 25.4;
+    case 'm':
+      return value * 1000;
+    default:
+      return value;
+  }
+}
+
+/**
+ * Infer mesh units from the bounding box diagonal. If a hint is provided,
+ * it takes precedence. Heuristic ranges are purposely loose and clamped to
+ * avoid absurd results.
+ */
+export function inferUnits(diagonal: number, hint?: Units): Units {
+  if (hint) return hint;
+  if (!isFinite(diagonal) || diagonal <= 0) return 'mm';
+
+  // Diagonal already in millimeters and reasonable (10mm - 2m)
+  if (diagonal >= 10 && diagonal <= 2000) return 'mm';
+
+  // Very large numbers are likely already in millimeters representing meter
+  // scale parts.
+  if (diagonal > 2000) return 'm';
+
+  // For small values (<10) decide between inches and meters
+  const asInchMM = diagonal * 25.4; // interpret value as inches then to mm
+  if (asInchMM >= 10 && asInchMM <= 2000) return 'inch';
+
+  return 'm';
+}

--- a/src/lib/validators/geometry.ts
+++ b/src/lib/validators/geometry.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const stlGeometrySchema = z
+  .object({
+    partId: z.string().uuid(),
+    fileUrl: z.string().optional(),
+    uploadId: z.string().optional(),
+    unitsHint: z.enum(['mm', 'inch', 'm']).optional(),
+  })
+  .refine((d) => d.fileUrl || d.uploadId, {
+    message: 'fileUrl or uploadId required',
+    path: ['fileUrl'],
+  });
+
+export type StlGeometryInput = z.infer<typeof stlGeometrySchema>;


### PR DESCRIPTION
## Summary
- implement STL parser supporting binary/ASCII with bbox, surface area, and volume metrics
- add units conversion and inference utilities
- expose `/api/parts/geometry/stl` endpoint to parse and persist metrics
- add validator for STL geometry requests

## Testing
- `npm run lint`
- `npx tsx test-stl.ts` *(custom validation of parser on 10mm cube in mm and inch units; file removed afterward)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5bbcb8b4832291aaf528bc08ef52