### PR TITLE
feat: add projected area calc and STEP mesh fallback

### DIFF
--- a/src/app/api/parts/geometry/step/route.ts
+++ b/src/app/api/parts/geometry/step/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { stepRequestSchema, StepRequest } from "@/lib/validators/step";
+import { maxProjectedArea } from "@/lib/geometry/projectedArea";
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: StepRequest;
+  try {
+    body = stepRequestSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const { partId, fileUrl, mesh } = body;
+  const { data: part, error: partErr } = await supabase
+    .from("parts")
+    .select("meta")
+    .eq("id", partId)
+    .eq("owner_id", user.id)
+    .single();
+  if (partErr || !part) {
+    return NextResponse.json({ error: "Part not found" }, { status: 404 });
+  }
+
+  if (fileUrl && !mesh) {
+    return NextResponse.json(
+      {
+        error: "STEP parsing not implemented. Please provide a faceted mesh.",
+      },
+      { status: 501 },
+    );
+  }
+
+  if (!mesh) {
+    return NextResponse.json({ error: "Mesh data required" }, { status: 400 });
+  }
+
+  const result = maxProjectedArea(mesh.tris);
+
+  const currentMeta = part.meta ?? {};
+  await supabase
+    .from("parts")
+    .update({ meta: { ...currentMeta, projected_area_cm2: result.area_cm2 } })
+    .eq("id", partId);
+
+  return NextResponse.json(result);
+}

--- a/src/lib/geometry/projectedArea.ts
+++ b/src/lib/geometry/projectedArea.ts
@@ -1,0 +1,64 @@
+export type Axis = 'x' | 'y' | 'z';
+
+/**
+ * Compute projected area of a triangle mesh along a given axis.
+ * @param tris Array of triangles, each triangle is [[x,y,z],[x,y,z],[x,y,z]] in mm.
+ * @param axis Axis onto which the area is projected.
+ * @returns Projected area in cm^2
+ */
+export function projectedAreaFromMesh(
+  tris: number[][][],
+  axis: Axis,
+): { area_cm2: number } {
+  const axisIndex = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
+  let areaComponent = 0;
+  for (const tri of tris) {
+    const [a, b, c] = tri;
+    const ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    const ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    const cross = [
+      ab[1] * ac[2] - ab[2] * ac[1],
+      ab[2] * ac[0] - ab[0] * ac[2],
+      ab[0] * ac[1] - ab[1] * ac[0],
+    ];
+    areaComponent += Math.abs(cross[axisIndex]);
+  }
+  // cross component is 2 * area * (n · axis), divide by 4 to avoid double counting
+  const area_mm2 = areaComponent / 4;
+  const area_cm2 = area_mm2 / 100;
+  return { area_cm2 };
+}
+
+/**
+ * Determine the axis with maximum projected area.
+ */
+export function maxProjectedArea(
+  tris: number[][][],
+): { axis: Axis; area_cm2: number } {
+  const axes: Axis[] = ['x', 'y', 'z'];
+  let max = { axis: 'x' as Axis, area_cm2: 0 };
+  for (const axis of axes) {
+    const { area_cm2 } = projectedAreaFromMesh(tris, axis);
+    if (area_cm2 > max.area_cm2) {
+      max = { axis, area_cm2 };
+    }
+  }
+  return max;
+}
+
+/**
+ * Compute projected area from bounding box dimensions.
+ * @param bbox [dx, dy, dz] in mm
+ * @param axis Axis of projection
+ * @returns Area in cm^2
+ */
+export function bboxProjectedArea(
+  bbox: [number, number, number],
+  axis: Axis,
+): number {
+  const axisIndex = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
+  const dims = bbox.slice();
+  dims.splice(axisIndex, 1);
+  const area_mm2 = dims[0] * dims[1];
+  return area_mm2 / 100;
+}

--- a/src/lib/validators/step.ts
+++ b/src/lib/validators/step.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const vec3 = z.tuple([z.number(), z.number(), z.number()]);
+const triangle = z.tuple([vec3, vec3, vec3]);
+const meshSchema = z.object({ tris: z.array(triangle).min(1) });
+
+export const stepRequestSchema = z
+  .object({ partId: z.string().uuid() })
+  .and(
+    z.union([
+      z.object({ fileUrl: z.string().url() }),
+      z.object({ mesh: meshSchema }),
+    ]),
+  );
+
+export type StepRequest = z.infer<typeof stepRequestSchema>;


### PR DESCRIPTION
## Summary
- compute mesh projected area with axis selection helpers
- expose POST /api/parts/geometry/step with mesh fallback and placeholder for STEP parsing
- validate requests for STEP geometry

## Testing
- `npx tsx -e "import { maxProjectedArea } from './src/lib/geometry/projectedArea'; const v0=[0,0,0],v1=[100,0,0],v2=[100,100,0],v3=[0,100,0]; const v4=[0,0,2],v5=[100,0,2],v6=[100,100,2],v7=[0,100,2]; const tris=[ [v0,v1,v2],[v0,v2,v3],[v4,v6,v5],[v4,v7,v6],[v0,v4,v5],[v0,v5,v1],[v1,v5,v6],[v1,v6,v2],[v2,v6,v7],[v2,v7,v3],[v3,v7,v4],[v3,v4,v0] ]; console.log(maxProjectedArea(tris));"`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5bc47e408322af211ed332e7dc22