### PR TITLE
feat: add capacity scheduling APIs

### DIFF
--- a/src/app/api/capacity/reserve/route.ts
+++ b/src/app/api/capacity/reserve/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const bodySchema = z.object({
+  machineId: z.string().uuid(),
+  day: z.string(),
+  minutes: z.number().int().min(1).max(20000),
+});
+
+export async function POST(req: Request) {
+  await requireAdmin();
+  let body;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const supabase = createClient();
+  const { data: existing, error: exErr } = await supabase
+    .from("machine_capacity_days")
+    .select("minutes_available, minutes_reserved")
+    .eq("machine_id", body.machineId)
+    .eq("day", body.day)
+    .single();
+  if (exErr && exErr.code !== "PGRST116") {
+    return NextResponse.json({ error: exErr.message }, { status: 500 });
+  }
+
+  const minutes_available = existing?.minutes_available ?? 0;
+  const minutes_reserved = (existing?.minutes_reserved ?? 0) + body.minutes;
+
+  const { data, error } = await supabase
+    .from("machine_capacity_days")
+    .upsert(
+      {
+        machine_id: body.machineId,
+        day: body.day,
+        minutes_available,
+        minutes_reserved,
+      },
+      { onConflict: "machine_id,day" }
+    )
+    .select("machine_id, day, minutes_available, minutes_reserved")
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, record: data });
+}
+

--- a/src/lib/capacity.ts
+++ b/src/lib/capacity.ts
@@ -1,0 +1,71 @@
+import { addDays, formatISO } from "date-fns";
+import { createClient } from "./supabase/server";
+
+/**
+ * Derive the number of minutes of machine capacity required for an item.
+ * The item is expected to include either a `capacity_minutes_reserved`
+ * property or a similar field inside `pricing_breakdown`.
+ */
+export function minutesNeededForItem(item: any): number {
+  const minutes =
+    item?.capacity_minutes_reserved ??
+    item?.capacity_minutes ??
+    item?.pricing_breakdown?.capacity_minutes_reserved ??
+    item?.pricing_breakdown?.capacity_minutes ??
+    0;
+  return typeof minutes === "number" && minutes > 0 ? minutes : 0;
+}
+
+interface EarliestSlotArgs {
+  machineId: string;
+  minutesRequired: number;
+  startDate?: Date;
+  maxDays?: number;
+  /** Optional flag for future use when differentiating expedite capacity */
+  expedite?: boolean;
+}
+
+/**
+ * Find the earliest date with enough remaining capacity for the requested
+ * number of minutes. Scans forward day-by-day from `startDate` (defaults to
+ * today) up to `maxDays`.
+ */
+export async function earliestSlot({
+  machineId,
+  minutesRequired,
+  startDate,
+  maxDays = 30,
+}: EarliestSlotArgs): Promise<{ date: string; minutes: number } | null> {
+  const start = startDate ? new Date(startDate) : new Date();
+  const end = addDays(start, maxDays);
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("machine_capacity_days")
+    .select("day, minutes_available, minutes_reserved")
+    .eq("machine_id", machineId)
+    .gte("day", formatISO(start, { representation: "date" }))
+    .lte("day", formatISO(end, { representation: "date" }))
+    .order("day");
+
+  if (error) {
+    console.error("earliestSlot query failed", error.message);
+    return null;
+  }
+
+  const map = new Map<string, number>();
+  for (const row of data ?? []) {
+    const date = formatISO(new Date(row.day), { representation: "date" });
+    const avail = (row.minutes_available ?? 0) - (row.minutes_reserved ?? 0);
+    map.set(date, avail);
+  }
+
+  for (let i = 0; i <= maxDays; i++) {
+    const d = formatISO(addDays(start, i), { representation: "date" });
+    const avail = map.get(d) ?? 0;
+    if (avail >= minutesRequired && minutesRequired > 0) {
+      return { date: d, minutes: avail };
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- implement capacity helpers to compute minutes and find earliest machine slot
- expose availability endpoint returning earliest slots based on capacity
- add admin-only endpoint to reserve machine capacity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5bcc76148322a3cc6bb815d5d9df