### PR TITLE
Add price breakdown modal and reusable components

### DIFF
--- a/src/app/(customer)/quote/[id]/page.tsx
+++ b/src/app/(customer)/quote/[id]/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import PriceExplainerModal from "@/components/quotes/PriceExplainerModal";
+import { formatCurrency } from "@/components/quotes/BreakdownRow";
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function QuotePage({ params }: Props) {
+  const supabase = createClient();
+  const { data: quote } = await supabase
+    .from("quotes")
+    .select("id,total,currency,quote_items(pricing_breakdown,process_code,lead_time_days)")
+    .eq("id", params.id)
+    .single();
+
+  if (!quote) {
+    notFound();
+  }
+
+  const item = quote.quote_items?.[0];
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 space-y-4">
+      <h1 className="text-2xl font-semibold">Quote {quote.id}</h1>
+      {quote.total !== null && (
+        <p className="text-lg">
+          Total: {formatCurrency(Number(quote.total), quote.currency as any)}
+        </p>
+      )}
+      {item?.pricing_breakdown && (
+        <PriceExplainerModal
+          breakdownJson={item.pricing_breakdown}
+          processKind={item.process_code}
+          leadTime={item.lead_time_days && item.lead_time_days <= 3 ? "expedite" : "standard"}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/src/components/quotes/Badges.tsx
+++ b/src/components/quotes/Badges.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+interface Props {
+  processKind?: string;
+  leadTime?: "standard" | "expedite";
+}
+
+const processLabels: Record<string, string> = {
+  cnc_milling: "CNC Milling",
+  cnc_turning: "CNC Turning",
+  sheet_metal: "Sheet Metal",
+  "3dp_fdm": "FDM 3D Printing",
+  "3dp_sla": "SLA 3D Printing",
+  "3dp_sls": "SLS 3D Printing",
+  injection_proto: "Injection Prototype",
+};
+
+const leadLabels: Record<string, string> = {
+  standard: "Standard",
+  expedite: "Expedite",
+};
+
+export default function Badges({ processKind, leadTime }: Props) {
+  return (
+    <div className="flex gap-2">
+      {processKind && (
+        <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs font-medium">
+          {processLabels[processKind] || processKind}
+        </span>
+      )}
+      {leadTime && (
+        <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs font-medium">
+          {leadLabels[leadTime] || leadTime}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/quotes/BreakdownRow.tsx
+++ b/src/components/quotes/BreakdownRow.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Info } from "lucide-react";
+
+export type Currency = "USD" | "EUR" | "INR";
+
+export interface BreakdownLine {
+  label: string;
+  value: number;
+  unit?: string;
+  info?: string;
+  kind:
+    | "material"
+    | "machining"
+    | "press"
+    | "mold"
+    | "setup"
+    | "finish"
+    | "overhead"
+    | "margin"
+    | "tax"
+    | "shipping"
+    | "carbon";
+}
+
+const ZERO_DECIMAL_CURRENCIES = new Set(["JPY", "KRW", "VND"]);
+
+export function formatCurrency(value: number, currency: Currency) {
+  const options: Intl.NumberFormatOptions = {
+    style: "currency",
+    currency,
+    minimumFractionDigits: ZERO_DECIMAL_CURRENCIES.has(currency) ? 0 : 2,
+    maximumFractionDigits: ZERO_DECIMAL_CURRENCIES.has(currency) ? 0 : 2,
+  };
+  return new Intl.NumberFormat(undefined, options).format(value);
+}
+
+interface Props {
+  line: BreakdownLine;
+  currency: Currency;
+}
+
+export default function BreakdownRow({ line, currency }: Props) {
+  return (
+    <tr className="text-sm">
+      <td className="py-1 pr-4">
+        <span>{line.label}</span>
+        {line.info && (
+          <span
+            title={line.info}
+            className="ml-1 text-gray-400 inline-flex align-middle"
+          >
+            <Info size={12} />
+          </span>
+        )}
+      </td>
+      <td className="py-1 text-right">
+        {formatCurrency(line.value, currency)}
+        {line.unit ? `/${line.unit}` : ""}
+      </td>
+    </tr>
+  );
+}
+

--- a/src/components/quotes/LineItemsTable.tsx
+++ b/src/components/quotes/LineItemsTable.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import BreakdownRow, { BreakdownLine, Currency } from "./BreakdownRow";
+
+interface Props {
+  lines: BreakdownLine[];
+  currency: Currency;
+}
+
+export default function LineItemsTable({ lines, currency }: Props) {
+  return (
+    <table className="w-full">
+      <tbody>
+        {lines.map((line, i) => (
+          <BreakdownRow key={i} line={line} currency={currency} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/src/components/quotes/PriceExplainerModal.tsx
+++ b/src/components/quotes/PriceExplainerModal.tsx
@@ -1,33 +1,48 @@
 "use client";
 
 import { useState } from "react";
+import Badges from "./Badges";
+import LineItemsTable from "./LineItemsTable";
+import TotalBar from "./TotalBar";
+import type { BreakdownLine, Currency } from "./BreakdownRow";
 
-// Modal to display a pricing breakdown and total from a JSON object.
-interface PriceBreakdown {
-  material?: number;
-  machining?: number;
-  finish?: number;
-  setup?: number;
-  tolerance?: number;
-  overhead?: number;
-  margin?: number;
-  tax?: number;
-  ship?: number;
-  carbon_offset?: number;
+export interface BreakdownWarning {
+  severity: "info" | "warn" | "error";
+  message: string;
+}
+
+export interface BreakdownJson {
+  lines: BreakdownLine[];
+  subtotal: number;
+  tax: number;
+  shipping: number;
+  total: number;
+  currency: Currency;
+  warnings?: BreakdownWarning[];
 }
 
 interface Props {
-  breakdownJson: PriceBreakdown;
+  breakdownJson: BreakdownJson;
+  processKind?: string;
+  leadTime?: "standard" | "expedite";
 }
 
-export default function PriceExplainerModal({ breakdownJson }: Props) {
+const warningColors: Record<"info" | "warn" | "error", string> = {
+  info: "bg-blue-50 text-blue-800",
+  warn: "bg-yellow-50 text-yellow-800",
+  error: "bg-red-50 text-red-800",
+};
+
+export default function PriceExplainerModal({
+  breakdownJson,
+  processKind,
+  leadTime,
+}: Props) {
   const [open, setOpen] = useState(false);
+  const [showCalc, setShowCalc] = useState(false);
 
-  const entries = Object.entries(breakdownJson).filter(
-    ([, value]) => typeof value === "number"
-  );
-
-  const total = entries.reduce((sum, [, value]) => sum + (value || 0), 0);
+  const subtotal = breakdownJson.lines.reduce((sum, l) => sum + l.value, 0);
+  const total = subtotal + breakdownJson.tax + breakdownJson.shipping;
 
   return (
     <>
@@ -40,21 +55,43 @@ export default function PriceExplainerModal({ breakdownJson }: Props) {
       </button>
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white rounded-md p-6 w-full max-w-md shadow">
-            <h2 className="text-lg font-semibold mb-4">Price Breakdown</h2>
-            <ul className="space-y-1 text-sm">
-              {entries.map(([key, value]) => (
-                <li key={key} className="flex justify-between">
-                  <span className="capitalize">{key.replace(/_/g, " ")}</span>
-                  <span>${value?.toFixed(2)}</span>
-                </li>
-              ))}
-              <li className="flex justify-between font-medium border-t pt-1 mt-2">
-                <span>Total</span>
-                <span>${total.toFixed(2)}</span>
-              </li>
-            </ul>
-            <div className="mt-4 text-right">
+          <div className="bg-white rounded-md p-6 w-full max-w-lg shadow space-y-4">
+            <Badges processKind={processKind} leadTime={leadTime} />
+            {breakdownJson.warnings?.map((w, i) => (
+              <div
+                key={i}
+                className={`px-2 py-1 rounded text-sm ${warningColors[w.severity]}`}
+              >
+                {w.message}
+              </div>
+            ))}
+            <LineItemsTable
+              lines={breakdownJson.lines}
+              currency={breakdownJson.currency}
+            />
+            <TotalBar
+              subtotal={subtotal}
+              tax={breakdownJson.tax}
+              shipping={breakdownJson.shipping}
+              total={total}
+              currency={breakdownJson.currency}
+            />
+            <div>
+              <button
+                type="button"
+                className="text-sm underline"
+                onClick={() => setShowCalc((s) => !s)}
+              >
+                {showCalc ? "Hide details" : "How we calculated this"}
+              </button>
+              {showCalc && (
+                <p className="mt-2 text-sm text-gray-600">
+                  Our price is derived from material, machine time, setup, finish, and
+                  other factors, plus tax and shipping.
+                </p>
+              )}
+            </div>
+            <div className="text-right">
               <button
                 className="px-4 py-2 bg-blue-600 text-white rounded"
                 onClick={() => setOpen(false)}

--- a/src/components/quotes/TotalBar.tsx
+++ b/src/components/quotes/TotalBar.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Currency, formatCurrency } from "./BreakdownRow";
+
+interface Props {
+  subtotal: number;
+  tax: number;
+  shipping: number;
+  total: number;
+  currency: Currency;
+}
+
+export default function TotalBar({ subtotal, tax, shipping, total, currency }: Props) {
+  return (
+    <div className="text-sm space-y-1 mt-2">
+      <div className="flex justify-between">
+        <span>Subtotal</span>
+        <span>{formatCurrency(subtotal, currency)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Tax</span>
+        <span>{formatCurrency(tax, currency)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Shipping</span>
+        <span>{formatCurrency(shipping, currency)}</span>
+      </div>
+      <div className="flex justify-between font-medium border-t pt-1 mt-1">
+        <span>Total</span>
+        <span>{formatCurrency(total, currency)}</span>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build reusable price explainer modal with badges, line items table, totals and collapsible details
- add currency-aware breakdown row, totals bar, and badges components
- wire price breakdown into instant quote form and customer quote page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5bd664348322ae3245ba6f4202ab