### PR TITLE
feat: geometry parsing and capacity scheduler

### DIFF
--- a/src/app/api/capacity/reserve/route.ts
+++ b/src/app/api/capacity/reserve/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { reserve } from "@/lib/capacity";
+import { createClient } from "@/lib/supabase/server";
+
+const bodySchema = z.object({
+  date: z.string(),
+  minutes: z.number().min(0),
+});
+
+// Reserve capacity minutes for a specific date. Admin only.
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  reserve(body.date, body.minutes);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/parts/geometry/step/route.ts
+++ b/src/app/api/parts/geometry/step/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { bufferGeometryFromMesh, geometryFromBufferGeometry } from "@/lib/geometry/stl";
+import { projectedArea } from "@/lib/geometry/projectedArea";
+import { stepRequestSchema } from "@/lib/validators/step";
+import { geometrySchema } from "@/lib/validators/geometry";
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: z.infer<typeof stepRequestSchema>;
+  try {
+    body = stepRequestSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const { data: part, error } = await supabase
+    .from("parts")
+    .select("*")
+    .eq("id", body.part_id)
+    .eq("owner_id", user.id)
+    .single();
+  if (error || !part) {
+    return NextResponse.json({ error: "Part not found" }, { status: 404 });
+  }
+
+  try {
+    const geom = bufferGeometryFromMesh(body.mesh);
+    const g = geometryFromBufferGeometry(geom);
+    g.projected_area_mm2 = projectedArea(geom);
+    const parsed = geometrySchema.parse(g);
+    await supabase
+      .from("parts")
+      .update({
+        volume_mm3: parsed.volume_mm3,
+        surface_area_mm2: parsed.surface_area_mm2,
+        bbox: parsed.bbox,
+      })
+      .eq("id", part.id);
+    return NextResponse.json({ geometry: parsed });
+  } catch (e: any) {
+    console.error(e);
+    return NextResponse.json(
+      { error: "Failed to compute geometry" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/parts/geometry/stl/route.ts
+++ b/src/app/api/parts/geometry/stl/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { computeStlGeometry } from "@/lib/geometry/stl";
+import { geometrySchema } from "@/lib/validators/geometry";
+
+const requestSchema = z.object({
+  part_id: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: z.infer<typeof requestSchema>;
+  try {
+    body = requestSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const { data: part, error } = await supabase
+    .from("parts")
+    .select("*")
+    .eq("id", body.part_id)
+    .eq("owner_id", user.id)
+    .single();
+  if (error || !part) {
+    return NextResponse.json({ error: "Part not found" }, { status: 404 });
+  }
+
+  try {
+    const { data: file } = await supabase.storage
+      .from("parts")
+      .download(part.file_url);
+    if (!file) throw new Error("File not found");
+    const arrayBuffer = await file.arrayBuffer();
+    const geom = computeStlGeometry(arrayBuffer);
+    const parsed = geometrySchema.parse(geom);
+    await supabase
+      .from("parts")
+      .update({
+        volume_mm3: parsed.volume_mm3,
+        surface_area_mm2: parsed.surface_area_mm2,
+        bbox: parsed.bbox,
+      })
+      .eq("id", part.id);
+    return NextResponse.json({ geometry: parsed });
+  } catch (e: any) {
+    console.error(e);
+    return NextResponse.json(
+      { error: "Failed to compute geometry" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/quotes/Badges.tsx
+++ b/src/components/quotes/Badges.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  meta?: Record<string, any>;
+}
+
+export default function Badges({ meta }: Props) {
+  if (!meta) return null;
+  return (
+    <div className="flex gap-2 mb-2 text-xs">
+      {meta.standard && (
+        <span className="bg-gray-200 px-2 py-1 rounded">
+          Standard: {meta.standard}
+        </span>
+      )}
+      {meta.expedite && (
+        <span className="bg-yellow-200 px-2 py-1 rounded">
+          Expedite: {meta.expedite}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/quotes/BreakdownRow.tsx
+++ b/src/components/quotes/BreakdownRow.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  label: string;
+  value: number;
+}
+
+export default function BreakdownRow({ label, value }: Props) {
+  return (
+    <tr>
+      <td className="py-1 capitalize">{label.replace(/_/g, " ")}</td>
+      <td className="py-1 text-right">${value.toFixed(2)}</td>
+    </tr>
+  );
+}

--- a/src/components/quotes/LineItemsTable.tsx
+++ b/src/components/quotes/LineItemsTable.tsx
@@ -1,0 +1,18 @@
+import BreakdownRow from "./BreakdownRow";
+
+interface Props {
+  breakdown: Record<string, number>;
+}
+
+export default function LineItemsTable({ breakdown }: Props) {
+  const entries = Object.entries(breakdown);
+  return (
+    <table className="w-full text-sm">
+      <tbody>
+        {entries.map(([k, v]) => (
+          <BreakdownRow key={k} label={k} value={v} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/quotes/PriceExplainerModal.tsx
+++ b/src/components/quotes/PriceExplainerModal.tsx
@@ -1,33 +1,25 @@
 "use client";
 
 import { useState } from "react";
+import LineItemsTable from "./LineItemsTable";
+import TotalBar from "./TotalBar";
+import Badges from "./Badges";
 
-// Modal to display a pricing breakdown and total from a JSON object.
-interface PriceBreakdown {
-  material?: number;
-  machining?: number;
-  finish?: number;
-  setup?: number;
-  tolerance?: number;
-  overhead?: number;
-  margin?: number;
-  tax?: number;
-  ship?: number;
-  carbon_offset?: number;
+interface BreakdownJson {
+  breakdown: Record<string, number>;
+  total?: number;
+  meta?: Record<string, any>;
 }
 
 interface Props {
-  breakdownJson: PriceBreakdown;
+  breakdownJson: BreakdownJson;
 }
 
 export default function PriceExplainerModal({ breakdownJson }: Props) {
   const [open, setOpen] = useState(false);
-
-  const entries = Object.entries(breakdownJson).filter(
-    ([, value]) => typeof value === "number"
-  );
-
-  const total = entries.reduce((sum, [, value]) => sum + (value || 0), 0);
+  const total =
+    breakdownJson.total ??
+    Object.values(breakdownJson.breakdown).reduce((s, v) => s + v, 0);
 
   return (
     <>
@@ -42,18 +34,9 @@ export default function PriceExplainerModal({ breakdownJson }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white rounded-md p-6 w-full max-w-md shadow">
             <h2 className="text-lg font-semibold mb-4">Price Breakdown</h2>
-            <ul className="space-y-1 text-sm">
-              {entries.map(([key, value]) => (
-                <li key={key} className="flex justify-between">
-                  <span className="capitalize">{key.replace(/_/g, " ")}</span>
-                  <span>${value?.toFixed(2)}</span>
-                </li>
-              ))}
-              <li className="flex justify-between font-medium border-t pt-1 mt-2">
-                <span>Total</span>
-                <span>${total.toFixed(2)}</span>
-              </li>
-            </ul>
+            <Badges meta={breakdownJson.meta} />
+            <LineItemsTable breakdown={breakdownJson.breakdown} />
+            <TotalBar total={total} />
             <div className="mt-4 text-right">
               <button
                 className="px-4 py-2 bg-blue-600 text-white rounded"
@@ -68,4 +51,3 @@ export default function PriceExplainerModal({ breakdownJson }: Props) {
     </>
   );
 }
-

--- a/src/components/quotes/TotalBar.tsx
+++ b/src/components/quotes/TotalBar.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  total: number;
+}
+
+export default function TotalBar({ total }: Props) {
+  return (
+    <div className="flex justify-between font-medium border-t mt-2 pt-2 text-sm">
+      <span>Total</span>
+      <span>${total.toFixed(2)}</span>
+    </div>
+  );
+}

--- a/src/lib/capacity.ts
+++ b/src/lib/capacity.ts
@@ -1,0 +1,36 @@
+import { addDays, formatISO } from "date-fns";
+
+const CAPACITY_PER_DAY_MIN = 8 * 60; // 8 hours
+const schedule: Record<string, number> = {};
+
+function dateKey(date: Date): string {
+  return formatISO(date, { representation: "date" });
+}
+
+export function reserve(date: string, minutes: number) {
+  schedule[date] = (schedule[date] || 0) + minutes;
+}
+
+export function earliestAvailable(minutes: number): string {
+  const today = new Date();
+  for (let i = 0; i < 365; i++) {
+    const d = addDays(today, i);
+    const key = dateKey(d);
+    const used = schedule[key] || 0;
+    if (used + minutes <= CAPACITY_PER_DAY_MIN) {
+      return key;
+    }
+  }
+  return dateKey(addDays(today, 365));
+}
+
+export function available(minutes: number) {
+  const standard = earliestAvailable(minutes);
+  const expediteDate = addDays(new Date(standard), -2);
+  const expedite = dateKey(expediteDate);
+  return { standard, expedite };
+}
+
+export function clearSchedule() {
+  for (const k of Object.keys(schedule)) delete schedule[k];
+}

--- a/src/lib/geometry/projectedArea.ts
+++ b/src/lib/geometry/projectedArea.ts
@@ -1,0 +1,21 @@
+import { BufferGeometry, Vector3 } from "three";
+
+/** Compute the projected area of a mesh on the XY plane. */
+export function projectedArea(geom: BufferGeometry): number {
+  const pos = geom.getAttribute("position");
+  const a = new Vector3();
+  const b = new Vector3();
+  const c = new Vector3();
+  let area = 0;
+  for (let i = 0; i < pos.count; i += 3) {
+    a.fromBufferAttribute(pos, i);
+    b.fromBufferAttribute(pos, i + 1);
+    c.fromBufferAttribute(pos, i + 2);
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const acx = c.x - a.x;
+    const acy = c.y - a.y;
+    area += Math.abs(abx * acy - aby * acx) / 2;
+  }
+  return area;
+}

--- a/src/lib/geometry/stl.ts
+++ b/src/lib/geometry/stl.ts
@@ -1,0 +1,61 @@
+import { BufferGeometry, Vector3, BufferAttribute } from "three";
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader";
+
+export interface GeometryData {
+  volume_mm3: number;
+  surface_area_mm2: number;
+  bbox: [number, number, number];
+  projected_area_mm2?: number;
+}
+
+/** Compute geometry metrics from a THREE.BufferGeometry. */
+export function geometryFromBufferGeometry(geom: BufferGeometry): GeometryData {
+  geom.computeBoundingBox();
+  const bbox = geom.boundingBox!;
+  const size = bbox.getSize(new Vector3());
+  const bboxArr: [number, number, number] = [size.x, size.y, size.z];
+
+  const pos = geom.getAttribute("position");
+  const vA = new Vector3();
+  const vB = new Vector3();
+  const vC = new Vector3();
+  const cb = new Vector3();
+  const ab = new Vector3();
+  let volume = 0;
+  let surface = 0;
+  for (let i = 0; i < pos.count; i += 3) {
+    vA.fromBufferAttribute(pos, i);
+    vB.fromBufferAttribute(pos, i + 1);
+    vC.fromBufferAttribute(pos, i + 2);
+    cb.subVectors(vC, vB);
+    ab.subVectors(vA, vB);
+    const cross = cb.cross(ab);
+    const area = cross.length() * 0.5;
+    surface += area;
+    volume += vA.dot(cross) / 6;
+  }
+  volume = Math.abs(volume);
+  surface = Math.abs(surface);
+  return { volume_mm3: volume, surface_area_mm2: surface, bbox: bboxArr };
+}
+
+/** Parse an STL file and compute geometry metrics. */
+export function computeStlGeometry(arrayBuffer: ArrayBuffer): GeometryData {
+  const loader = new STLLoader();
+  const geom = loader.parse(arrayBuffer);
+  return geometryFromBufferGeometry(geom);
+}
+
+/** Helper to build BufferGeometry from raw mesh data. */
+export function bufferGeometryFromMesh(mesh: {
+  vertices: number[][];
+  faces: number[][];
+}): BufferGeometry {
+  const geometry = new BufferGeometry();
+  const flatVerts = new Float32Array(mesh.vertices.flat());
+  geometry.setAttribute("position", new BufferAttribute(flatVerts, 3));
+  const flatIdx = mesh.faces.flat();
+  geometry.setIndex(flatIdx);
+  geometry.computeVertexNormals();
+  return geometry;
+}

--- a/src/lib/geometry/units.ts
+++ b/src/lib/geometry/units.ts
@@ -1,0 +1,16 @@
+export type Unit = "mm" | "inch";
+
+/** Convert a value from the given unit to millimeters. */
+export function toMM(value: number, unit: Unit): number {
+  return unit === "mm" ? value : value * 25.4;
+}
+
+/** Convert a value in millimeters to the requested unit. */
+export function fromMM(value: number, unit: Unit): number {
+  return unit === "mm" ? value : value / 25.4;
+}
+
+/** Convert between metric and imperial units. */
+export function convert(value: number, from: Unit, to: Unit): number {
+  return fromMM(toMM(value, from), to);
+}

--- a/src/lib/validators/geometry.ts
+++ b/src/lib/validators/geometry.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const geometrySchema = z.object({
+  volume_mm3: z.number().nonnegative(),
+  surface_area_mm2: z.number().nonnegative(),
+  bbox: z.tuple([z.number(), z.number(), z.number()]),
+  projected_area_mm2: z.number().nonnegative().optional(),
+  meta: z.record(z.any()).optional(),
+});
+
+export type Geometry = z.infer<typeof geometrySchema>;

--- a/src/lib/validators/step.ts
+++ b/src/lib/validators/step.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const meshSchema = z.object({
+  vertices: z.array(z.tuple([z.number(), z.number(), z.number()])),
+  faces: z.array(z.tuple([z.number(), z.number(), z.number()])),
+});
+
+export const stepRequestSchema = z.object({
+  part_id: z.string().uuid(),
+  mesh: meshSchema,
+});
+
+export type StepRequest = z.infer<typeof stepRequestSchema>;


### PR DESCRIPTION
## Summary
- compute STL and mesh geometry with unit helpers and projected area
- introduce capacity scheduler APIs
- refine price explainer UI components

## Testing
- `npx tsx test.ts` *(pricing test skipped: Invariant: cookies() expects to have requestAsyncStorage, none available.)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad5be314fc8322a9fb0ca8d1562933