### PR TITLE
feat: refine price explainer modal

### DIFF
--- a/src/components/quotes/PriceExplainerModal.tsx
+++ b/src/components/quotes/PriceExplainerModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 // Modal to display a pricing breakdown and total from a JSON object.
 interface PriceBreakdown {
@@ -23,11 +23,20 @@ interface Props {
 export default function PriceExplainerModal({ breakdownJson }: Props) {
   const [open, setOpen] = useState(false);
 
-  const entries = Object.entries(breakdownJson).filter(
-    ([, value]) => typeof value === "number"
+  const entries = useMemo(
+    () =>
+      Object.entries(breakdownJson).filter(
+        ([, value]) => typeof value === "number"
+      ),
+    [breakdownJson]
   );
 
-  const total = entries.reduce((sum, [, value]) => sum + (value || 0), 0);
+  const total = useMemo(
+    () => entries.reduce((sum, [, value]) => sum + (value || 0), 0),
+    [entries]
+  );
+
+  const format = (value: number) => `$${value.toFixed(2)}`;
 
   return (
     <>
@@ -39,19 +48,25 @@ export default function PriceExplainerModal({ breakdownJson }: Props) {
         View price details
       </button>
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+        >
           <div className="bg-white rounded-md p-6 w-full max-w-md shadow">
             <h2 className="text-lg font-semibold mb-4">Price Breakdown</h2>
             <ul className="space-y-1 text-sm">
               {entries.map(([key, value]) => (
                 <li key={key} className="flex justify-between">
-                  <span className="capitalize">{key.replace(/_/g, " ")}</span>
-                  <span>${value?.toFixed(2)}</span>
+                  <span className="capitalize">
+                    {key.replace(/_/g, " ")}
+                  </span>
+                  <span>{format(value ?? 0)}</span>
                 </li>
               ))}
               <li className="flex justify-between font-medium border-t pt-1 mt-2">
                 <span>Total</span>
-                <span>${total.toFixed(2)}</span>
+                <span>{format(total)}</span>
               </li>
             </ul>
             <div className="mt-4 text-right">


### PR DESCRIPTION
## Summary
- enhance price explainer modal with memoized breakdown and formatted totals

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c021bb083229596beda992abea7