### PR TITLE
feat(db): add multi-process machine support

### DIFF
--- a/sql/migrations/027_multi_process_machines.sql
+++ b/sql/migrations/027_multi_process_machines.sql
@@ -1,0 +1,22 @@
+begin;
+alter table public.materials add column if not exists category text check (category in ('metal','resin','alloy','plastic')) default null;
+alter table public.machines add column if not exists process_kind text check (process_kind in ('cnc_milling','cnc_turning','injection_molding','casting')) default 'cnc_milling';
+alter table public.machines add column if not exists max_work_envelope_mm jsonb;
+alter table public.machines add column if not exists params jsonb;
+create table if not exists public.machine_resins (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid references public.machines(id) on delete cascade,
+  material_id uuid references public.materials(id) on delete cascade,
+  resin_rate_multiplier numeric default 1.0,
+  unique(machine_id, material_id)
+);
+create table if not exists public.machine_alloys (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid references public.machines(id) on delete cascade,
+  material_id uuid references public.materials(id) on delete cascade,
+  alloy_rate_multiplier numeric default 1.0,
+  unique(machine_id, material_id)
+);
+alter table public.quote_items add column if not exists process_kind text;
+update public.quote_items set process_kind = coalesce(process_kind, (select p.process_code from public.parts p where p.id = public.quote_items.part_id)) where process_kind is null;
+commit;

--- a/sql/policies.sql
+++ b/sql/policies.sql
@@ -99,6 +99,18 @@ drop policy if exists machine_finishes_admin_all on public.machine_finishes;
 create policy machine_finishes_admin_all on public.machine_finishes
   for all using (public.is_admin()) with check (public.is_admin());
 
+-- Machine resins (admin/staff only)
+alter table public.machine_resins enable row level security;
+drop policy if exists machine_resins_admin_all on public.machine_resins;
+create policy machine_resins_admin_all on public.machine_resins
+  for all using (public.is_admin()) with check (public.is_admin());
+
+-- Machine alloys (admin/staff only)
+alter table public.machine_alloys enable row level security;
+drop policy if exists machine_alloys_admin_all on public.machine_alloys;
+create policy machine_alloys_admin_all on public.machine_alloys
+  for all using (public.is_admin()) with check (public.is_admin());
+
 -- Parts
 alter table public.parts enable row level security;
 drop policy if exists parts_owner_select on public.parts;


### PR DESCRIPTION
## Summary
- add multi-process machine migration for materials and quote items
- restrict new machine link tables to admin/staff via RLS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error in PriceExplainerModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62424598832287c16e79353609fa