### PR TITLE
Add machine link CRUD and pricing simulation

### DIFF
--- a/src/app/api/machines/[id]/alloys/route.ts
+++ b/src/app/api/machines/[id]/alloys/route.ts
@@ -4,8 +4,8 @@ import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 
 const schema = z.object({
-  finish_id: z.string().uuid(),
-  finish_rate_multiplier: z.number().optional(),
+  alloy_id: z.string().uuid(),
+  alloy_rate_multiplier: z.number().optional(),
   is_active: z.boolean().optional(),
 });
 
@@ -21,13 +21,14 @@ export async function GET(req: NextRequest, { params }: Params) {
   const PAGE_SIZE = 10;
   const supabase = createClient();
   const { data, count, error } = await supabase
-    .from("machine_finishes")
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)", {
-      count: "exact",
-    })
+    .from("machine_alloys")
+    .select(
+      "id, alloy_id, alloy_rate_multiplier, is_active, alloys(name)",
+      { count: "exact" }
+    )
     .eq("machine_id", params.id)
-    .order("finishes.name")
-    .ilike("finishes.name", `%${search}%`)
+    .order("alloys.name")
+    .ilike("alloys.name", `%${search}%`)
     .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -46,9 +47,11 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { data, error } = await supabase
-    .from("machine_finishes")
+    .from("machine_alloys")
     .insert({ ...body, machine_id: params.id })
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)")
+    .select(
+      "id, alloy_id, alloy_rate_multiplier, is_active, alloys(name)"
+    )
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -72,11 +75,13 @@ export async function PUT(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { data, error } = await supabase
-    .from("machine_finishes")
+    .from("machine_alloys")
     .update(body)
     .eq("id", id)
     .eq("machine_id", params.id)
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)")
+    .select(
+      "id, alloy_id, alloy_rate_multiplier, is_active, alloys(name)"
+    )
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -93,7 +98,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { error } = await supabase
-    .from("machine_finishes")
+    .from("machine_alloys")
     .delete()
     .eq("id", id)
     .eq("machine_id", params.id);
@@ -102,4 +107,3 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   return NextResponse.json({ ok: true });
 }
-

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
@@ -13,9 +13,9 @@ interface Params {
   params: { id: string };
 }
 
-export async function GET(req: Request, { params }: Params) {
+export async function GET(req: NextRequest, { params }: Params) {
   await requireAdmin();
-  const { searchParams } = new URL(req.url);
+  const searchParams = req.nextUrl.searchParams;
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
@@ -35,7 +35,7 @@ export async function GET(req: Request, { params }: Params) {
   return NextResponse.json({ data, count });
 }
 
-export async function POST(req: Request, { params }: Params) {
+export async function POST(req: NextRequest, { params }: Params) {
   await requireAdmin();
   let body;
   try {
@@ -56,9 +56,9 @@ export async function POST(req: Request, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function PUT(req: Request, { params }: Params) {
+export async function PUT(req: NextRequest, { params }: Params) {
   await requireAdmin();
-  const { searchParams } = new URL(req.url);
+  const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
@@ -84,9 +84,9 @@ export async function PUT(req: Request, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function DELETE(req: Request, { params }: Params) {
+export async function DELETE(req: NextRequest, { params }: Params) {
   await requireAdmin();
-  const { searchParams } = new URL(req.url);
+  const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });

--- a/src/app/api/machines/[id]/resins/route.ts
+++ b/src/app/api/machines/[id]/resins/route.ts
@@ -4,8 +4,8 @@ import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 
 const schema = z.object({
-  finish_id: z.string().uuid(),
-  finish_rate_multiplier: z.number().optional(),
+  resin_id: z.string().uuid(),
+  resin_rate_multiplier: z.number().optional(),
   is_active: z.boolean().optional(),
 });
 
@@ -21,13 +21,14 @@ export async function GET(req: NextRequest, { params }: Params) {
   const PAGE_SIZE = 10;
   const supabase = createClient();
   const { data, count, error } = await supabase
-    .from("machine_finishes")
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)", {
-      count: "exact",
-    })
+    .from("machine_resins")
+    .select(
+      "id, resin_id, resin_rate_multiplier, is_active, resins(name)",
+      { count: "exact" }
+    )
     .eq("machine_id", params.id)
-    .order("finishes.name")
-    .ilike("finishes.name", `%${search}%`)
+    .order("resins.name")
+    .ilike("resins.name", `%${search}%`)
     .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -46,9 +47,11 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { data, error } = await supabase
-    .from("machine_finishes")
+    .from("machine_resins")
     .insert({ ...body, machine_id: params.id })
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)")
+    .select(
+      "id, resin_id, resin_rate_multiplier, is_active, resins(name)"
+    )
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -72,11 +75,13 @@ export async function PUT(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { data, error } = await supabase
-    .from("machine_finishes")
+    .from("machine_resins")
     .update(body)
     .eq("id", id)
     .eq("machine_id", params.id)
-    .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)")
+    .select(
+      "id, resin_id, resin_rate_multiplier, is_active, resins(name)"
+    )
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -93,7 +98,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   const supabase = createClient();
   const { error } = await supabase
-    .from("machine_finishes")
+    .from("machine_resins")
     .delete()
     .eq("id", id)
     .eq("machine_id", params.id);
@@ -102,4 +107,3 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   return NextResponse.json({ ok: true });
 }
-

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
@@ -23,7 +23,7 @@ interface Params {
   params: { id: string };
 }
 
-export async function GET(_req: Request, { params }: Params) {
+export async function GET(_req: NextRequest, { params }: Params) {
   await requireAdmin();
   const supabase = createClient();
   const { data, error } = await supabase
@@ -37,7 +37,7 @@ export async function GET(_req: Request, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function PUT(req: Request, { params }: Params) {
+export async function PUT(req: NextRequest, { params }: Params) {
   await requireAdmin();
   let body;
   try {
@@ -59,7 +59,7 @@ export async function PUT(req: Request, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function DELETE(_req: Request, { params }: Params) {
+export async function DELETE(_req: NextRequest, { params }: Params) {
   await requireAdmin();
   const supabase = createClient();
   const { error } = await supabase.from("machines").delete().eq("id", params.id);

--- a/src/app/api/machines/route.ts
+++ b/src/app/api/machines/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
@@ -19,9 +19,9 @@ const machineSchema = z.object({
   is_active: z.boolean().optional(),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   await requireAdmin();
-  const { searchParams } = new URL(req.url);
+  const searchParams = req.nextUrl.searchParams;
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
@@ -38,7 +38,7 @@ export async function GET(req: Request) {
   return NextResponse.json({ data, count });
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   await requireAdmin();
   let body;
   try {

--- a/src/app/api/pricing/simulate/route.ts
+++ b/src/app/api/pricing/simulate/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { priceItem } from "@/lib/pricing";
+import { geometrySchema } from "@/lib/validators/pricing";
+
+const requestSchema = z.object({
+  process_kind: z.enum([
+    "cnc_milling",
+    "cnc_turning",
+    "sheet_metal",
+    "3dp_fdm",
+    "3dp_sla",
+    "3dp_sls",
+    "injection_proto",
+  ]),
+  material_id: z.string().uuid(),
+  finish_id: z.string().uuid().optional(),
+  tolerance_id: z.string().uuid().optional(),
+  quantity: z.number().int().positive(),
+  lead_time: z.enum(["standard", "expedite"]),
+  geometry: geometrySchema,
+});
+
+const buckets = new Map<string, { tokens: number; last: number }>();
+const TOKENS = 20;
+const REFILL_MS = 60_000;
+
+function consume(key: string): boolean {
+  const now = Date.now();
+  const bucket = buckets.get(key) || { tokens: TOKENS, last: now };
+  const delta = now - bucket.last;
+  bucket.tokens = Math.min(TOKENS, bucket.tokens + (delta / REFILL_MS) * TOKENS);
+  bucket.last = now;
+  if (bucket.tokens < 1) {
+    buckets.set(key, bucket);
+    return false;
+  }
+  bucket.tokens -= 1;
+  buckets.set(key, bucket);
+  return true;
+}
+
+export async function POST(req: NextRequest) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0] ?? "anon";
+  if (!consume(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let body;
+  try {
+    body = requestSchema.parse(await req.json());
+  } catch (err: any) {
+    const msg = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  const supabase = createClient();
+
+  let material = (
+    await supabase
+      .from("materials")
+      .select("*")
+      .eq("id", body.material_id)
+      .eq("is_active", true)
+      .maybeSingle()
+  ).data;
+  if (!material) {
+    material = (
+      await supabase
+        .from("resins")
+        .select("*")
+        .eq("id", body.material_id)
+        .eq("is_active", true)
+        .maybeSingle()
+    ).data;
+  }
+  if (!material) {
+    material = (
+      await supabase
+        .from("alloys")
+        .select("*")
+        .eq("id", body.material_id)
+        .eq("is_active", true)
+        .maybeSingle()
+    ).data;
+  }
+  if (!material) {
+    return NextResponse.json({ error: "Material not found" }, { status: 404 });
+  }
+
+  const [
+    { data: finish },
+    { data: tolerance },
+    { data: rateCard },
+    { data: machines },
+    { data: mm },
+    { data: mf },
+    { data: mr },
+    { data: ma },
+  ] = await Promise.all([
+    body.finish_id
+      ? supabase
+          .from("finishes")
+          .select("*")
+          .eq("id", body.finish_id)
+          .eq("is_active", true)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    body.tolerance_id
+      ? supabase
+          .from("tolerances")
+          .select("*")
+          .eq("id", body.tolerance_id)
+          .eq("is_active", true)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    supabase
+      .from("rate_cards")
+      .select("*")
+      .eq("is_active", true)
+      .limit(1)
+      .maybeSingle(),
+    supabase.from("machines").select("*").eq("is_active", true),
+    supabase
+      .from("machine_materials")
+      .select("machine_id, material_id, material_rate_multiplier, is_active"),
+    supabase
+      .from("machine_finishes")
+      .select("machine_id, finish_id, finish_rate_multiplier, is_active"),
+    supabase
+      .from("machine_resins")
+      .select("machine_id, resin_id, resin_rate_multiplier, is_active"),
+    supabase
+      .from("machine_alloys")
+      .select("machine_id, alloy_id, alloy_rate_multiplier, is_active"),
+  ]);
+
+  const materialLinks = [
+    ...(mm ?? []),
+    ...(mr ?? []).map((r: any) => ({
+      machine_id: r.machine_id,
+      material_id: r.resin_id,
+      material_rate_multiplier: r.resin_rate_multiplier,
+      is_active: r.is_active,
+    })),
+    ...(ma ?? []).map((a: any) => ({
+      machine_id: a.machine_id,
+      material_id: a.alloy_id,
+      material_rate_multiplier: a.alloy_rate_multiplier,
+      is_active: a.is_active,
+    })),
+  ].filter((l) => l.is_active !== false);
+
+  const finishLinks = (mf ?? [])
+    .filter((l) => l.is_active !== false)
+    .map((l) => ({
+      machine_id: l.machine_id,
+      finish_id: l.finish_id,
+      finish_rate_multiplier: l.finish_rate_multiplier,
+    }));
+
+  const pricing = await priceItem({
+    process: body.process_kind,
+    quantity: body.quantity,
+    material,
+    finish: finish || undefined,
+    tolerance: tolerance || undefined,
+    geometry: body.geometry,
+    lead_time: body.lead_time,
+    rate_card: rateCard || {},
+    machines: machines || [],
+    machineMaterials: materialLinks.map((l) => ({
+      machine_id: l.machine_id,
+      material_id: l.material_id,
+      material_rate_multiplier: l.material_rate_multiplier,
+    })),
+    machineFinishes: finishLinks,
+  });
+
+  return NextResponse.json(pricing);
+}


### PR DESCRIPTION
## Summary
- extend machine API endpoints to use NextRequest and support admin-only CRUD
- add resin and alloy link endpoints for machines
- implement pricing simulation endpoint with per-IP rate limiting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error in PriceExplainerModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6253e910832290e1d05fd1e716d7