### PR TITLE
Add dynamic instant quote pricing UI and details modal

### DIFF
--- a/src/app/(customer)/instant-quote/page.tsx
+++ b/src/app/(customer)/instant-quote/page.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import InstantQuoteForm from "@/components/quotes/InstantQuoteForm";
+import PriceExplainerModal, { BreakdownJson } from "@/components/quotes/PriceExplainerModal";
+import { PricingResult } from "@/lib/pricing";
+import { formatCurrency } from "@/components/quotes/BreakdownRow";
 
 interface Props {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -14,6 +17,22 @@ export default function InstantQuotePage({ searchParams }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [price, setPrice] = useState<PricingResult | null>(null);
+  const [breakdown, setBreakdown] = useState<BreakdownJson | null>(null);
+  const [processKind, setProcessKind] = useState<string>("");
+  const [leadTime, setLeadTime] = useState<string>("standard");
+
+  const handlePricing = (info: {
+    price: PricingResult;
+    breakdown: BreakdownJson;
+    processKind: string;
+    leadTime: string;
+  }) => {
+    setPrice(info.price);
+    setBreakdown(info.breakdown);
+    setProcessKind(info.processKind);
+    setLeadTime(info.leadTime);
+  };
 
   const requestQuote = async () => {
     if (!quoteId) return;
@@ -36,19 +55,32 @@ export default function InstantQuotePage({ searchParams }: Props) {
     <div className="max-w-2xl mx-auto py-10">
       <h1 className="text-2xl font-semibold mb-6">Instant Quote</h1>
       {partId ? (
-        <InstantQuoteForm partId={partId} />
+        <InstantQuoteForm partId={partId} onPricingChange={handlePricing} />
       ) : (
         <p className="text-sm text-gray-500">No part selected.</p>
       )}
-      <div className="mt-6">
-        <button
-          onClick={requestQuote}
-          disabled={!quoteId || loading}
-          className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
-        >
-          Request Quote
-        </button>
-      </div>
+      {price && breakdown && (
+        <div className="mt-6 p-4 bg-gray-100 rounded space-y-2">
+          <p className="text-sm">
+            Unit price: {formatCurrency(price.unit, breakdown.currency as any)}
+          </p>
+          <p className="text-lg font-medium">
+            Total: {formatCurrency(price.total, breakdown.currency as any)}
+          </p>
+          <PriceExplainerModal
+            breakdownJson={breakdown}
+            processKind={processKind}
+            leadTime={leadTime}
+          />
+          <button
+            onClick={requestQuote}
+            disabled={!quoteId || loading}
+            className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+          >
+            Request Quote
+          </button>
+        </div>
+      )}
       {toast && (
         <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
           {toast}
@@ -57,3 +89,4 @@ export default function InstantQuotePage({ searchParams }: Props) {
     </div>
   );
 }
+

--- a/src/components/quotes/InstantQuoteForm.tsx
+++ b/src/components/quotes/InstantQuoteForm.tsx
@@ -1,43 +1,42 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import { calculatePricing, PricingResult } from "@/lib/pricing";
 import { Geometry } from "@/lib/validators/pricing";
 import { createClient } from "@/lib/supabase/client";
-import PriceExplainerModal, { BreakdownJson } from "./PriceExplainerModal";
-import { formatCurrency, BreakdownLine } from "./BreakdownRow";
-
-const formSchema = z.object({
-  material_id: z.string(),
-  finish_id: z.string().optional(),
-  tolerance_id: z.string().optional(),
-  quantity: z.number().min(1),
-  units: z.enum(["mm", "inch"]),
-  lead_time: z.enum(["standard", "expedite"]),
-});
-
-type FormValues = z.infer<typeof formSchema>;
+import { BreakdownJson } from "./PriceExplainerModal";
+import { BreakdownLine } from "./BreakdownRow";
 
 interface Props {
   partId: string;
+  onPricingChange?: (info: {
+    price: PricingResult;
+    breakdown: BreakdownJson;
+    processKind: string;
+    leadTime: string;
+  }) => void;
 }
 
-export default function InstantQuoteForm({ partId }: Props) {
-  const router = useRouter();
+export default function InstantQuoteForm({ partId, onPricingChange }: Props) {
   const [part, setPart] = useState<any | null>(null);
   const [materials, setMaterials] = useState<any[]>([]);
   const [finishes, setFinishes] = useState<any[]>([]);
   const [tolerances, setTolerances] = useState<any[]>([]);
   const [machines, setMachines] = useState<any[]>([]);
   const [rateCard, setRateCard] = useState<any | null>(null);
-  const [price, setPrice] = useState<PricingResult | null>(null);
-  const [breakdown, setBreakdown] = useState<BreakdownJson | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
 
-  const { register, handleSubmit, watch, setValue } = useForm<FormValues>({
-    defaultValues: { quantity: 1, units: "mm", lead_time: "standard" },
+  const { register, watch, setValue } = useForm<any>({
+    defaultValues: {
+      quantity: 1,
+      cavities: 1,
+      projected_area_cm2: 0,
+      annual_volume: 0,
+      machining_allowance_pct: 0,
+      heat_treat: false,
+      lead_time: "standard",
+    },
   });
 
   useEffect(() => {
@@ -50,7 +49,6 @@ export default function InstantQuoteForm({ partId }: Props) {
         .single();
       if (!partData) return;
 
-      // compute geometry if missing
       if (
         partData.volume_mm3 === null ||
         partData.surface_area_mm2 === null ||
@@ -71,9 +69,21 @@ export default function InstantQuoteForm({ partId }: Props) {
 
       const [materialsRes, finishesRes, tolerancesRes, machinesRes, rateCardRes] =
         await Promise.all([
-          supabase.from("materials").select("*").eq("is_active", true),
-          supabase.from("finishes").select("*").eq("is_active", true),
-          supabase.from("tolerances").select("*").eq("is_active", true),
+          supabase
+            .from("materials")
+            .select("*")
+            .eq("is_active", true)
+            .eq("process_code", partData.process_code),
+          supabase
+            .from("finishes")
+            .select("*")
+            .eq("is_active", true)
+            .eq("process_code", partData.process_code),
+          supabase
+            .from("tolerances")
+            .select("*")
+            .eq("is_active", true)
+            .eq("process_code", partData.process_code),
           supabase
             .from("machines")
             .select("*")
@@ -87,17 +97,18 @@ export default function InstantQuoteForm({ partId }: Props) {
             .single(),
         ]);
 
-      setPart(partData);
-      setMaterials(materialsRes.data ?? []);
-      setFinishes(finishesRes.data ?? []);
-      setTolerances(tolerancesRes.data ?? []);
-      setMachines(machinesRes.data ?? []);
-      setRateCard(rateCardRes.data ?? null);
+  setPart(partData);
+  setMaterials(materialsRes.data ?? []);
+  setFinishes(finishesRes.data ?? []);
+  setTolerances(tolerancesRes.data ?? []);
+  setMachines(machinesRes.data ?? []);
+  setRateCard(rateCardRes.data ?? null);
 
-      if (materialsRes.data && materialsRes.data[0]) {
-        setValue("material_id", materialsRes.data[0].id);
-      }
-      setValue("units", partData.units || "mm");
+  if (materialsRes.data && materialsRes.data[0]) {
+    setValue("material_id", materialsRes.data[0].id);
+    setValue("resin_id", materialsRes.data[0].id);
+    setValue("alloy_id", materialsRes.data[0].id);
+  }
     }
     load();
   }, [partId, setValue]);
@@ -108,24 +119,20 @@ export default function InstantQuoteForm({ partId }: Props) {
   const quantity = watch("quantity");
   const leadTime = watch("lead_time");
 
+  const resinId = watch("resin_id");
+  const cavities = watch("cavities");
+  const projectedArea = watch("projected_area_cm2");
+  const annualVolume = watch("annual_volume");
+
+  const alloyId = watch("alloy_id");
+  const castingType = watch("casting_type");
+  const machiningAllowance = watch("machining_allowance_pct");
+  const heatTreat = watch("heat_treat");
+
   function buildBreakdown(pricing: PricingResult, currency: string): BreakdownJson {
-    const map: Record<string, { label: string; kind: BreakdownLine["kind"] }> = {
-      material: { label: "Material", kind: "material" },
-      machining: { label: "Machining", kind: "machining" },
-      setup_fee: { label: "Setup", kind: "setup" },
-      finish: { label: "Finish", kind: "finish" },
-      overhead: { label: "Overhead", kind: "overhead" },
-      expedite: { label: "Expedite", kind: "overhead" },
-      quantity_discount: { label: "Quantity Discount", kind: "overhead" },
-      carbon_offset: { label: "Carbon Offset", kind: "carbon" },
-      margin: { label: "Margin", kind: "margin" },
-      tier_adjustment: { label: "Tier Adjustment", kind: "overhead" },
-    };
     const lines: BreakdownLine[] = [];
     for (const [key, value] of Object.entries(pricing.breakdown)) {
-      if (key === "tax" || key === "shipping") continue;
-      const meta = map[key] || { label: key.replace(/_/g, " "), kind: "overhead" };
-      lines.push({ label: meta.label, value, kind: meta.kind });
+      lines.push({ label: key.replace(/_/g, " "), value, kind: "overhead" });
     }
     return {
       lines,
@@ -133,21 +140,28 @@ export default function InstantQuoteForm({ partId }: Props) {
       tax: pricing.tax,
       shipping: pricing.shipping,
       total: pricing.total,
-      currency: (currency as any) || "USD",
+      currency: currency as any,
     };
   }
 
   useEffect(() => {
     if (!part || !rateCard) return;
-    const material = materials.find((m) => m.id === materialId);
+    const processKind = part.process_code || "";
+
+    const material =
+      materials.find((m) => m.id === materialId || m.id === resinId || m.id === alloyId) ||
+      materials[0];
     if (!material) return;
+
     const finish = finishes.find((f) => f.id === finishId);
     const tolerance = tolerances.find((t) => t.id === toleranceId);
+
     const geom: Geometry = {
       volume_mm3: part.volume_mm3 ?? 0,
       surface_area_mm2: part.surface_area_mm2 ?? 0,
       bbox: (part.bbox as [number, number, number]) ?? [0, 0, 0],
     };
+
     const bbox = geom.bbox;
     const machine = machines
       .filter((m) => {
@@ -184,9 +198,13 @@ export default function InstantQuoteForm({ partId }: Props) {
           break;
       }
     }
+
+    const qty =
+      processKind.startsWith("injection") ? annualVolume || 1 : quantity || 1;
+
     const pricing = calculatePricing({
       process: part.process_code,
-      quantity: quantity || 1,
+      quantity: qty,
       material,
       finish: finish || undefined,
       tolerance: tolerance || undefined,
@@ -194,147 +212,289 @@ export default function InstantQuoteForm({ partId }: Props) {
       lead_time: leadTime,
       rate_card: rc,
     });
-    setPrice(pricing);
+
     const currency = rateCard?.currency || "USD";
-    setBreakdown(buildBreakdown(pricing, currency));
+    const breakdown = buildBreakdown(pricing, currency);
+
+    onPricingChange?.({
+      price: pricing,
+      breakdown,
+      processKind: part.process_code,
+      leadTime,
+    });
+
+    async function checkFeasibility() {
+      try {
+        const res = await fetch("/api/quotes/feasibility", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            part_id: partId,
+            process_code: part.process_code,
+            inputs: {
+              material_id: materialId || resinId || alloyId,
+              finish_id: finishId,
+              tolerance_id: toleranceId,
+              quantity: qty,
+              cavities,
+              projected_area_cm2: projectedArea,
+              annual_volume: annualVolume,
+              casting_type: castingType,
+              machining_allowance_pct: machiningAllowance,
+              heat_treat: heatTreat,
+              lead_time: leadTime,
+            },
+          }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setWarnings(data.warnings || []);
+        } else {
+          setWarnings([]);
+        }
+      } catch {
+        setWarnings([]);
+      }
+    }
+    checkFeasibility();
   }, [
+    part,
+    rateCard,
+    materials,
+    finishes,
+    tolerances,
+    machines,
     materialId,
     finishId,
     toleranceId,
     quantity,
     leadTime,
-    machines,
-    materials,
-    finishes,
-    tolerances,
-    part,
-    rateCard,
+    resinId,
+    cavities,
+    projectedArea,
+    annualVolume,
+    alloyId,
+    castingType,
+    machiningAllowance,
+    heatTreat,
+    onPricingChange,
+    partId,
   ]);
-
-  const onSubmit = handleSubmit(async (values) => {
-    if (!part) return;
-    try {
-      const parsed = formSchema.parse(values);
-      const res = await fetch("/api/quotes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...parsed,
-          partId: part.id,
-          process_code: part.process_code,
-        }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        router.push(`/quote/${data.quote.id}`);
-      } else {
-        console.error(await res.json());
-      }
-    } catch (err) {
-      console.error(err);
-    }
-  });
 
   if (!part) {
     return <p className="text-sm text-gray-500">Loading...</p>;
   }
 
+  const processKind = part.process_code.startsWith("cnc")
+    ? "cnc"
+    : part.process_code.includes("injection")
+    ? "injection"
+    : part.process_code.includes("casting")
+    ? "casting"
+    : "other";
+
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      {price && breakdown && (
-        <div className="p-4 bg-gray-100 rounded space-y-2">
-          <p className="text-lg font-medium">
-            Estimated Price: {formatCurrency(price.total, breakdown.currency)}
-          </p>
-          <PriceExplainerModal
-            breakdownJson={breakdown}
-            processKind={part.process_code}
-            leadTime={leadTime}
-          />
-        </div>
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      {warnings.length > 0 && (
+        <ul className="p-2 bg-yellow-50 text-yellow-700 rounded text-sm space-y-1">
+          {warnings.map((w, i) => (
+            <li key={i}>{w}</li>
+          ))}
+        </ul>
       )}
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Material</label>
-        <select
-          {...register("material_id", { required: true })}
-          className="w-full border rounded p-2"
-        >
-          {materials.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {processKind === "cnc" && (
+        <>
+          <div>
+            <label className="block text-sm font-medium mb-1">Material</label>
+            <select
+              {...register("material_id", { required: true })}
+              className="w-full border rounded p-2"
+            >
+              {materials.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Finish</label>
-        <select
-          {...register("finish_id")}
-          className="w-full border rounded p-2"
-        >
-          <option value="">None</option>
-          {finishes.map((f) => (
-            <option key={f.id} value={f.id}>
-              {f.name}
-            </option>
-          ))}
-        </select>
-      </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Finish</label>
+            <select {...register("finish_id")} className="w-full border rounded p-2">
+              <option value="">None</option>
+              {finishes.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Tolerance</label>
-        <select
-          {...register("tolerance_id")}
-          className="w-full border rounded p-2"
-        >
-          <option value="">Standard</option>
-          {tolerances.map((t) => (
-            <option key={t.id} value={t.id}>
-              {t.name}
-            </option>
-          ))}
-        </select>
-      </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Tolerance</label>
+            <select
+              {...register("tolerance_id")}
+              className="w-full border rounded p-2"
+            >
+              <option value="">Standard</option>
+              {tolerances.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-      <div className="flex space-x-4">
-        <div className="flex-1">
-          <label className="block text-sm font-medium mb-1">Quantity</label>
-          <select
-            {...register("quantity", { valueAsNumber: true })}
-            className="w-full border rounded p-2"
-          >
-            {[1, 2, 5, 10, 25, 50, 100].map((q) => (
-              <option key={q} value={q}>
-                {q}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="flex-1">
-          <label className="block text-sm font-medium mb-1">Units</label>
-          <select {...register("units")} className="w-full border rounded p-2">
-            <option value="mm">Metric (mm)</option>
-            <option value="inch">Imperial (inch)</option>
-          </select>
-        </div>
-      </div>
+          <div className="flex space-x-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">Quantity</label>
+              <select
+                {...register("quantity", { valueAsNumber: true })}
+                className="w-full border rounded p-2"
+              >
+                {[1, 2, 5, 10, 25, 50, 100].map((q) => (
+                  <option key={q} value={q}>
+                    {q}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">Lead time</label>
+              <select
+                {...register("lead_time")}
+                className="w-full border rounded p-2"
+              >
+                <option value="standard">Standard</option>
+                <option value="expedite">Expedite</option>
+              </select>
+            </div>
+          </div>
+        </>
+      )}
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Lead time</label>
-        <select
-          {...register("lead_time")}
-          className="w-full border rounded p-2"
-        >
-          <option value="standard">Standard</option>
-          <option value="expedite">Expedite</option>
-        </select>
-      </div>
+      {processKind === "injection" && (
+        <>
+          <div>
+            <label className="block text-sm font-medium mb-1">Resin</label>
+            <select
+              {...register("resin_id", { required: true })}
+              className="w-full border rounded p-2"
+            >
+              {materials.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
-        Get Quote
-      </button>
+          <div className="flex space-x-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">Cavities</label>
+              <input
+                type="number"
+                {...register("cavities", { valueAsNumber: true })}
+                className="w-full border rounded p-2"
+                min={1}
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">
+                Projected Area (cm²)
+              </label>
+              <input
+                type="number"
+                {...register("projected_area_cm2", { valueAsNumber: true })}
+                className="w-full border rounded p-2"
+                min={0}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Annual Volume (optional)
+            </label>
+            <input
+              type="number"
+              {...register("annual_volume", { valueAsNumber: true })}
+              className="w-full border rounded p-2"
+              min={0}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Lead time</label>
+            <select
+              {...register("lead_time")}
+              className="w-full border rounded p-2"
+            >
+              <option value="standard">Standard</option>
+              <option value="expedite">Expedite</option>
+            </select>
+          </div>
+        </>
+      )}
+
+      {processKind === "casting" && (
+        <>
+          <div>
+            <label className="block text-sm font-medium mb-1">Alloy</label>
+            <select
+              {...register("alloy_id", { required: true })}
+              className="w-full border rounded p-2"
+            >
+              {materials.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Casting Type</label>
+            <select
+              {...register("casting_type")}
+              className="w-full border rounded p-2"
+            >
+              <option value="die_cast">Die Cast</option>
+              <option value="sand_cast">Sand Cast</option>
+              <option value="investment_cast">Investment Cast</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Machining Allowance (%)
+            </label>
+            <input
+              type="number"
+              {...register("machining_allowance_pct", { valueAsNumber: true })}
+              className="w-full border rounded p-2"
+              min={0}
+            />
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <input type="checkbox" {...register("heat_treat")} />
+            <label className="text-sm">Heat Treat</label>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Lead time</label>
+            <select
+              {...register("lead_time")}
+              className="w-full border rounded p-2"
+            >
+              <option value="standard">Standard</option>
+              <option value="expedite">Expedite</option>
+            </select>
+          </div>
+        </>
+      )}
     </form>
   );
 }

--- a/src/components/quotes/PriceExplainerModal.tsx
+++ b/src/components/quotes/PriceExplainerModal.tsx
@@ -1,99 +1,79 @@
-diff --git a/src/components/quotes/PriceExplainerModal.tsx b/src/components/quotes/PriceExplainerModal.tsx
-index 521bd1f962d82115d98b351010a01b77ad63fe07..93e2cfc86cd11a2357684cdd4679a1e7ae6b15cd 100644
---- a/src/components/quotes/PriceExplainerModal.tsx
-+++ b/src/components/quotes/PriceExplainerModal.tsx
-@@ -1,71 +1,86 @@
- "use client";
- 
--import { useState } from "react";
-+import { useMemo, useState } from "react";
- 
- // Modal to display a pricing breakdown and total from a JSON object.
- interface PriceBreakdown {
-   material?: number;
-   machining?: number;
-   finish?: number;
-   setup?: number;
-   tolerance?: number;
-   overhead?: number;
-   margin?: number;
-   tax?: number;
-   ship?: number;
-   carbon_offset?: number;
- }
- 
- interface Props {
-   breakdownJson: PriceBreakdown;
- }
- 
- export default function PriceExplainerModal({ breakdownJson }: Props) {
-   const [open, setOpen] = useState(false);
- 
--  const entries = Object.entries(breakdownJson).filter(
--    ([, value]) => typeof value === "number"
-+  const entries = useMemo(
-+    () =>
-+      Object.entries(breakdownJson).filter(
-+        ([, value]) => typeof value === "number"
-+      ),
-+    [breakdownJson]
-   );
- 
--  const total = entries.reduce((sum, [, value]) => sum + (value || 0), 0);
-+  const total = useMemo(
-+    () => entries.reduce((sum, [, value]) => sum + (value || 0), 0),
-+    [entries]
-+  );
-+
-+  const format = (value: number) => `$${value.toFixed(2)}`;
- 
-   return (
-     <>
-       <button
-         type="button"
-         className="text-sm underline"
-         onClick={() => setOpen(true)}
-       >
-         View price details
-       </button>
-       {open && (
--        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-+        <div
-+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-+          role="dialog"
-+          aria-modal="true"
-+        >
-           <div className="bg-white rounded-md p-6 w-full max-w-md shadow">
-             <h2 className="text-lg font-semibold mb-4">Price Breakdown</h2>
-             <ul className="space-y-1 text-sm">
-               {entries.map(([key, value]) => (
-                 <li key={key} className="flex justify-between">
--                  <span className="capitalize">{key.replace(/_/g, " ")}</span>
--                  <span>${value?.toFixed(2)}</span>
-+                  <span className="capitalize">
-+                    {key.replace(/_/g, " ")}
-+                  </span>
-+                  <span>{format(value ?? 0)}</span>
-                 </li>
-               ))}
-               <li className="flex justify-between font-medium border-t pt-1 mt-2">
-                 <span>Total</span>
--                <span>${total.toFixed(2)}</span>
-+                <span>{format(total)}</span>
-               </li>
-             </ul>
-             <div className="mt-4 text-right">
-               <button
-                 className="px-4 py-2 bg-blue-600 text-white rounded"
-                 onClick={() => setOpen(false)}
-               >
-                 Close
-               </button>
-             </div>
-           </div>
-         </div>
-       )}
-     </>
-   );
- }
- 
+"use client";
+
+import { useState } from "react";
+import BreakdownRow, { BreakdownLine, formatCurrency } from "./BreakdownRow";
+
+export interface BreakdownJson {
+  lines: BreakdownLine[];
+  subtotal: number;
+  tax: number;
+  shipping: number;
+  total: number;
+  currency: string;
+}
+
+interface Props {
+  breakdownJson: BreakdownJson;
+  processKind: string;
+  leadTime: string;
+}
+
+export default function PriceExplainerModal({
+  breakdownJson,
+  processKind,
+  leadTime,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="text-sm underline"
+        onClick={() => setOpen(true)}
+      >
+        View price details
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="bg-white rounded-md p-6 w-full max-w-md shadow">
+            <h2 className="text-lg font-semibold mb-1">Price Breakdown</h2>
+            <p className="text-xs text-gray-500 mb-4">
+              {processKind} · {leadTime === "expedite" ? "Expedited" : "Standard"}
+            </p>
+            <table className="w-full mb-4">
+              <tbody>
+                {breakdownJson.lines.map((line) => (
+                  <BreakdownRow
+                    key={line.label}
+                    line={line}
+                    currency={breakdownJson.currency as any}
+                  />
+                ))}
+                <tr className="text-sm font-medium border-t">
+                  <td className="py-1 pr-4">Total</td>
+                  <td className="py-1 text-right">
+                    {formatCurrency(breakdownJson.total, breakdownJson.currency as any)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div className="text-right">
+              <button
+                className="px-4 py-2 bg-blue-600 text-white rounded"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Render process-specific fields in InstantQuoteForm with automatic pricing and feasibility checks
- Display unit and total pricing with detailed breakdown via PriceExplainerModal
- Hook up Instant Quote page to show pricing and request quotes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad626442b483229e6c26f34da7e1a0