### PR TITLE
Seed demo data for catalogs and order flow

### DIFF
--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { fileURLToPath } from 'url';
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -10,71 +11,282 @@ if (!url || !serviceRoleKey) {
 
 const supabase = createClient(url, serviceRoleKey);
 
-async function seed() {
+async function getOrCreateUser(email: string, password: string) {
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (error && !data?.user) {
+    const { data: list } = await supabase.auth.admin.listUsers();
+    const existing = list.users.find((u: any) => u.email === email);
+    if (!existing) throw error;
+    return existing.id;
+  }
+  return data!.user!.id;
+}
+
+export async function seed() {
   // Processes
   const { error: procErr } = await supabase.from('processes').upsert([
     { code: 'cnc_milling', name: 'CNC Milling' },
     { code: 'cnc_turning', name: 'CNC Turning' },
-    { code: 'sheet_metal', name: 'Sheet Metal' },
-    { code: '3dp_fdm', name: 'FDM 3D Printing' },
-    { code: '3dp_sla', name: 'SLA 3D Printing' },
-    { code: '3dp_sls', name: 'SLS 3D Printing' },
-    { code: 'injection_proto', name: 'Injection Prototype' }
+    { code: 'injection_molding', name: 'Injection Molding' },
+    { code: 'casting', name: 'Casting' }
   ], { onConflict: 'code' });
   if (procErr) throw procErr;
 
   // Materials
   const { error: matErr } = await supabase.from('materials').upsert([
-    { process_code: 'cnc_milling', name: 'Aluminum 6061', density_kg_m3: 2700, cost_per_kg: 5 },
-    { process_code: 'sheet_metal', name: 'Aluminum Sheet', density_kg_m3: 2700, cost_per_kg: 4 },
-    { process_code: '3dp_fdm', name: 'PLA', density_kg_m3: 1240, cost_per_kg: 20 },
-    { process_code: '3dp_sla', name: 'Resin', density_kg_m3: 1100, cost_per_kg: 150 },
-    { process_code: '3dp_sls', name: 'Nylon', density_kg_m3: 950, cost_per_kg: 70 },
-    { process_code: 'injection_proto', name: 'ABS', density_kg_m3: 1040, cost_per_kg: 2.5 }
+    { process_code: 'cnc_milling', name: 'Aluminum 6061', category: 'metal', density_kg_m3: 2700, cost_per_kg: 6 },
+    { process_code: 'cnc_turning', name: 'Stainless Steel 304', category: 'alloy', density_kg_m3: 8000, cost_per_kg: 8 },
+    { process_code: 'injection_molding', name: 'Nylon 12', category: 'resin', density_kg_m3: 1010, cost_per_kg: 3 },
+    { process_code: 'casting', name: 'Zamak 3', category: 'alloy', density_kg_m3: 6800, cost_per_kg: 5 }
   ], { onConflict: 'process_code,name' });
   if (matErr) throw matErr;
 
   // Finishes
   const { error: finErr } = await supabase.from('finishes').upsert([
     { process_code: 'cnc_milling', name: 'Anodized', type: 'coating', cost_per_m2: 10, setup_fee: 30 },
-    { process_code: 'sheet_metal', name: 'Powder Coat', type: 'coating', cost_per_m2: 8, setup_fee: 25 }
+    { process_code: 'cnc_turning', name: 'Polished', type: 'polish', cost_per_m2: 8, setup_fee: 20 },
+    { process_code: 'casting', name: 'As Cast', type: 'raw', cost_per_m2: 0, setup_fee: 0 }
   ], { onConflict: 'process_code,name' });
   if (finErr) throw finErr;
 
   // Tolerances
   const { error: tolErr } = await supabase.from('tolerances').upsert([
     { process_code: 'cnc_milling', name: 'Standard', tol_min_mm: -0.1, tol_max_mm: 0.1, cost_multiplier: 1 },
-    { process_code: 'cnc_milling', name: 'High', tol_min_mm: -0.05, tol_max_mm: 0.05, cost_multiplier: 1.2 }
+    { process_code: 'cnc_milling', name: 'High', tol_min_mm: -0.05, tol_max_mm: 0.05, cost_multiplier: 1.2 },
+    { process_code: 'cnc_turning', name: 'Standard', tol_min_mm: -0.1, tol_max_mm: 0.1, cost_multiplier: 1 }
   ], { onConflict: 'process_code,name' });
   if (tolErr) throw tolErr;
 
-  // Rate cards
-  const { error: rateErr } = await supabase.from('rate_cards').upsert([
-    {
-      region: 'us',
-      currency: 'USD',
-      three_axis_rate_per_min: 1.2,
-      five_axis_rate_per_min: 1.5,
-      turning_rate_per_min: 1.0,
-      sheet_setup_fee: 15,
-      bend_rate_per_bend: 0.5,
-      laser_rate_per_min: 0.8,
-      fdm_rate_per_cm3: 0.2,
-      sla_rate_per_cm3: 0.5,
-      sls_rate_per_cm3: 0.6,
-      injection_mold_setup: 500,
-      injection_part_rate: 2,
-      machine_setup_fee: 50,
-      tax_rate: 0.07,
-      shipping_flat: 15
-    }
-  ], { onConflict: 'region' });
+  // Rate card
+  const { error: rateErr } = await supabase.from('rate_cards').upsert([{
+    region: 'us-east',
+    currency: 'USD',
+    three_axis_rate_per_min: 1.2,
+    five_axis_rate_per_min: 1.6,
+    turning_rate_per_min: 1.0,
+    machine_setup_fee: 50,
+    tax_rate: 0.07,
+    shipping_flat: 15
+  }], { onConflict: 'region' });
   if (rateErr) throw rateErr;
+
+  // Users and profiles
+  const adminId = await getOrCreateUser('admin@example.com', 'password');
+  const buyerId = await getOrCreateUser('buyer@example.com', 'password');
+
+  const { error: profErr } = await supabase.from('profiles').upsert([
+    { id: adminId, email: 'admin@example.com', full_name: 'Demo Admin', role: 'admin' },
+    { id: buyerId, email: 'buyer@example.com', full_name: 'Acme Buyer', role: 'customer' }
+  ]);
+  if (profErr) throw profErr;
+
+  // Customer
+  const { data: custData, error: custErr } = await supabase.from('customers').upsert([{
+    id: '00000000-0000-0000-0000-000000000010',
+    owner_id: buyerId,
+    name: 'Acme Corp',
+    website: 'https://acme.example'
+  }], { onConflict: 'id' }).select().single();
+  if (custErr) throw custErr;
+  const customerId = custData.id;
+
+  // Machines
+  const { data: machines, error: machErr } = await supabase.from('machines').upsert([
+    { name: 'HAAS VF-2SS', process_code: 'cnc_milling', process_kind: 'cnc_milling', axis_count: 3, rate_per_min: 1.2, setup_fee: 50 },
+    { name: 'Hermle C42', process_code: 'cnc_milling', process_kind: 'cnc_milling', axis_count: 5, rate_per_min: 1.6, setup_fee: 75 },
+    { name: 'Mazak Quick Turn', process_code: 'cnc_turning', process_kind: 'cnc_turning', axis_count: 2, rate_per_min: 1.0, setup_fee: 40 },
+    { name: 'Arburg 200T', process_code: 'injection_molding', process_kind: 'injection_molding', axis_count: 0, rate_per_min: 0.03, setup_fee: 100 },
+    { name: 'Buhler Casting Line', process_code: 'casting', process_kind: 'casting', axis_count: 0, rate_per_min: 0.05, setup_fee: 200 }
+  ], { onConflict: 'name' }).select();
+  if (machErr) throw machErr;
+
+  const machineMap: Record<string, string> = {};
+  machines?.forEach((m: any) => { machineMap[m.name] = m.id; });
+
+  // Link machines to materials/finishes
+  const { data: materials } = await supabase.from('materials').select('id,name');
+  const { data: finishes } = await supabase.from('finishes').select('id,name');
+
+  const aluminumId = materials?.find(m => m.name === 'Aluminum 6061')?.id;
+  const steelId = materials?.find(m => m.name === 'Stainless Steel 304')?.id;
+  const nylonId = materials?.find(m => m.name === 'Nylon 12')?.id;
+  const zamakId = materials?.find(m => m.name === 'Zamak 3')?.id;
+
+  const anodizedId = finishes?.find(f => f.name === 'Anodized')?.id;
+  const polishedId = finishes?.find(f => f.name === 'Polished')?.id;
+  const asCastId = finishes?.find(f => f.name === 'As Cast')?.id;
+
+  if (aluminumId && steelId) {
+    await supabase.from('machine_materials').upsert([
+      { machine_id: machineMap['HAAS VF-2SS'], material_id: aluminumId },
+      { machine_id: machineMap['Hermle C42'], material_id: aluminumId },
+      { machine_id: machineMap['Hermle C42'], material_id: steelId },
+      { machine_id: machineMap['Mazak Quick Turn'], material_id: steelId }
+    ]);
+  }
+  if (nylonId) {
+    await supabase.from('machine_resins').upsert([
+      { machine_id: machineMap['Arburg 200T'], material_id: nylonId }
+    ]);
+  }
+  if (zamakId) {
+    await supabase.from('machine_alloys').upsert([
+      { machine_id: machineMap['Buhler Casting Line'], material_id: zamakId }
+    ]);
+  }
+  if (anodizedId && polishedId && asCastId) {
+    await supabase.from('machine_finishes').upsert([
+      { machine_id: machineMap['HAAS VF-2SS'], finish_id: anodizedId },
+      { machine_id: machineMap['Hermle C42'], finish_id: anodizedId },
+      { machine_id: machineMap['Mazak Quick Turn'], finish_id: polishedId },
+      { machine_id: machineMap['Buhler Casting Line'], finish_id: asCastId }
+    ]);
+  }
+
+  // Capacity days
+  const days = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + i);
+    return d.toISOString().slice(0, 10);
+  });
+  for (const name in machineMap) {
+    const entries = days.map(day => ({
+      machine_id: machineMap[name],
+      day,
+      minutes_available: 480
+    }));
+    await supabase.from('machine_capacity_days').upsert(entries, { onConflict: 'machine_id,day' });
+  }
+
+  // Part
+  const { data: partData, error: partErr } = await supabase.from('parts').upsert([{
+    id: '00000000-0000-0000-0000-000000000020',
+    owner_id: buyerId,
+    customer_id: customerId,
+    file_url: 'https://example.com/fixture1.stl',
+    file_name: 'fixture1.stl',
+    file_ext: 'stl',
+    size_bytes: 123456,
+    process_code: 'cnc_milling'
+  }], { onConflict: 'id' }).select().single();
+  if (partErr) throw partErr;
+  const partId = partData.id;
+
+  // Quotes
+  const quotes = [
+    { id: '00000000-0000-0000-0000-000000000030', status: 'draft' },
+    { id: '00000000-0000-0000-0000-000000000031', status: 'sent' },
+    { id: '00000000-0000-0000-0000-000000000032', status: 'accepted' }
+  ];
+  for (const q of quotes) {
+    const { error } = await supabase.from('quotes').upsert([{
+      id: q.id,
+      customer_id: customerId,
+      created_by: buyerId,
+      status: q.status,
+      region: 'us-east',
+      subtotal: 100,
+      tax: 7,
+      total: 107
+    }], { onConflict: 'id' });
+    if (error) throw error;
+  }
+
+  // Quote items
+  const { data: tolData } = await supabase.from('tolerances').select('id,name,process_code');
+  const tolStdMill = tolData?.find(t => t.name === 'Standard' && t.process_code === 'cnc_milling')?.id;
+  const tolStdTurn = tolData?.find(t => t.name === 'Standard' && t.process_code === 'cnc_turning')?.id;
+  const tolHighMill = tolData?.find(t => t.name === 'High' && t.process_code === 'cnc_milling')?.id;
+
+  await supabase.from('quote_items').upsert([
+    {
+      id: '00000000-0000-0000-0000-000000000040',
+      quote_id: '00000000-0000-0000-0000-000000000030',
+      part_id: partId,
+      process_code: 'cnc_milling',
+      material_id: aluminumId,
+      finish_id: anodizedId,
+      tolerance_id: tolStdMill,
+      quantity: 1,
+      unit_price: 100,
+      line_total: 100,
+      machine_id: machineMap['Hermle C42']
+    },
+    {
+      id: '00000000-0000-0000-0000-000000000041',
+      quote_id: '00000000-0000-0000-0000-000000000031',
+      part_id: partId,
+      process_code: 'cnc_turning',
+      material_id: steelId,
+      finish_id: polishedId,
+      tolerance_id: tolStdTurn,
+      quantity: 1,
+      unit_price: 120,
+      line_total: 120,
+      machine_id: machineMap['Mazak Quick Turn']
+    },
+    {
+      id: '00000000-0000-0000-0000-000000000042',
+      quote_id: '00000000-0000-0000-0000-000000000032',
+      part_id: partId,
+      process_code: 'cnc_milling',
+      material_id: aluminumId,
+      finish_id: anodizedId,
+      tolerance_id: tolHighMill,
+      quantity: 1,
+      unit_price: 150,
+      line_total: 150,
+      machine_id: machineMap['HAAS VF-2SS']
+    }
+  ], { onConflict: 'id' });
+
+  // Messages
+  await supabase.from('messages').upsert([
+    {
+      id: '00000000-0000-0000-0000-000000000060',
+      quote_id: '00000000-0000-0000-0000-000000000032',
+      sender_id: buyerId,
+      sender_role: 'customer',
+      content: 'Can you expedite this order?'
+    },
+    {
+      id: '00000000-0000-0000-0000-000000000061',
+      quote_id: '00000000-0000-0000-0000-000000000032',
+      sender_id: adminId,
+      sender_role: 'staff',
+      content: 'Yes, we can ship in two days.'
+    }
+  ], { onConflict: 'id' });
+
+  // Order
+  await supabase.from('orders').upsert([{
+    id: '00000000-0000-0000-0000-000000000050',
+    quote_id: '00000000-0000-0000-0000-000000000032',
+    customer_id: customerId,
+    status: 'created',
+    total: 107
+  }], { onConflict: 'id' });
+
+  await supabase.from('order_items').upsert([{
+    order_id: '00000000-0000-0000-0000-000000000050',
+    quote_item_id: '00000000-0000-0000-0000-000000000042',
+    part_id: partId,
+    process_code: 'cnc_milling',
+    quantity: 1,
+    unit_price: 150,
+    line_total: 150
+  }], { onConflict: 'order_id,quote_item_id' });
 
   console.log('Seeding complete');
 }
 
-seed().then(() => process.exit(0)).catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  seed().then(() => process.exit(0)).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/docs/DEMO-DATA.md
+++ b/docs/DEMO-DATA.md
@@ -1,0 +1,31 @@
+# Demo Data
+
+The seed scripts provide a minimal dataset for demonstrating the quoting and order flow.
+
+## Catalogs
+- **Processes:** CNC Milling, CNC Turning, Injection Molding, Casting
+- **Materials:** Aluminum 6061 (metal), Stainless Steel 304 (alloy), Nylon 12 (resin), Zamak 3 (alloy)
+- **Finishes:** Anodized, Polished, As Cast
+- **Tolerances:** Standard and High for milling, Standard for turning
+- **Rate Card:** US-East region with USD pricing
+
+## Machines
+- HAAS VF-2SS – 3‑axis milling
+- Hermle C42 – 5‑axis milling
+- Mazak Quick Turn – turning center
+- Arburg 200T – 200 ton injection press
+- Buhler Casting Line – die casting
+
+Each machine is linked to compatible materials/finishes and given 30 days of 8‑hour capacity.
+
+## Users and Customer
+- `admin@example.com` – administrator
+- `buyer@example.com` – customer for **Acme Corp**
+
+## Sample Flow
+1. Part `fixture1.stl` uploaded for Acme Corp.
+2. Three quotes created (draft, sent, accepted) with corresponding quote items.
+3. Conversation on accepted quote shows customer and staff messages.
+4. Accepted quote generates an order with one order item.
+
+Run `npm run db:seed` to populate the data or `tsx scripts/reset-demo.ts` to reset the demo environment.

--- a/scripts/reset-demo.ts
+++ b/scripts/reset-demo.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js';
+import { fileURLToPath } from 'url';
+import { seed } from '../db/seed';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRoleKey) {
+  console.error('Missing SUPABASE env vars');
+  process.exit(1);
+}
+
+const supabase = createClient(url, serviceRoleKey);
+
+export async function resetDemo() {
+  const tables = [
+    'machine_capacity_days',
+    'machine_alloys',
+    'machine_resins',
+    'machine_finishes',
+    'machine_materials',
+    'machines',
+    'order_items',
+    'orders',
+    'messages',
+    'quote_items',
+    'quotes',
+    'parts',
+    'customers',
+    'profiles',
+    'rate_cards',
+    'tolerances',
+    'finishes',
+    'materials',
+    'processes'
+  ];
+
+  for (const table of tables) {
+    const { error } = await supabase.from(table).delete().neq('id', '00000000-0000-0000-0000-000000000000');
+    if (error) console.error(`Error clearing ${table}:`, error.message);
+  }
+
+  const { data: list } = await supabase.auth.admin.listUsers();
+  for (const u of list.users) {
+    if (['admin@example.com', 'buyer@example.com'].includes(u.email ?? '')) {
+      await supabase.auth.admin.deleteUser(u.id);
+    }
+  }
+
+  await seed();
+  console.log('Demo data reset complete');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  resetDemo().then(() => process.exit(0)).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/sql/seed.sql
+++ b/sql/seed.sql
@@ -1,0 +1,159 @@
+-- Demo data seed
+-- Catalogs
+insert into public.processes (code, name) values
+  ('cnc_milling','CNC Milling'),
+  ('cnc_turning','CNC Turning'),
+  ('injection_molding','Injection Molding'),
+  ('casting','Casting')
+on conflict (code) do update set name=excluded.name;
+
+insert into public.materials (process_code, name, category, density_kg_m3, cost_per_kg) values
+  ('cnc_milling','Aluminum 6061','metal',2700,6),
+  ('cnc_turning','Stainless Steel 304','alloy',8000,8),
+  ('injection_molding','Nylon 12','resin',1010,3),
+  ('casting','Zamak 3','alloy',6800,5)
+on conflict (process_code,name) do update set category=excluded.category,
+  density_kg_m3=excluded.density_kg_m3, cost_per_kg=excluded.cost_per_kg;
+
+insert into public.finishes (process_code, name, type, cost_per_m2, setup_fee) values
+  ('cnc_milling','Anodized','coating',10,30),
+  ('cnc_turning','Polished','polish',8,20),
+  ('casting','As Cast','raw',0,0)
+on conflict (process_code,name) do update set type=excluded.type,
+  cost_per_m2=excluded.cost_per_m2, setup_fee=excluded.setup_fee;
+
+insert into public.tolerances (process_code, name, tol_min_mm, tol_max_mm, cost_multiplier) values
+  ('cnc_milling','Standard',-0.1,0.1,1),
+  ('cnc_milling','High',-0.05,0.05,1.2),
+  ('cnc_turning','Standard',-0.1,0.1,1)
+on conflict (process_code,name) do update set
+  tol_min_mm=excluded.tol_min_mm, tol_max_mm=excluded.tol_max_mm, cost_multiplier=excluded.cost_multiplier;
+
+insert into public.rate_cards (region, currency, three_axis_rate_per_min, five_axis_rate_per_min, turning_rate_per_min, machine_setup_fee, tax_rate, shipping_flat)
+values ('us-east','USD',1.2,1.6,1.0,50,0.07,15)
+on conflict (region) do update set currency=excluded.currency,
+ three_axis_rate_per_min=excluded.three_axis_rate_per_min,
+ five_axis_rate_per_min=excluded.five_axis_rate_per_min,
+ turning_rate_per_min=excluded.turning_rate_per_min,
+ machine_setup_fee=excluded.machine_setup_fee,
+ tax_rate=excluded.tax_rate,
+ shipping_flat=excluded.shipping_flat;
+
+-- Users and customer
+with admin_user as (
+  insert into auth.users (email, encrypted_password, email_confirmed_at)
+  values ('admin@example.com', crypt('password', gen_salt('bf')), now())
+  on conflict (email) do update set email=excluded.email
+  returning id
+), customer_user as (
+  insert into auth.users (email, encrypted_password, email_confirmed_at)
+  values ('buyer@example.com', crypt('password', gen_salt('bf')), now())
+  on conflict (email) do update set email=excluded.email
+  returning id
+), admin_profile as (
+  insert into public.profiles (id,email,full_name,role)
+  select id,'admin@example.com','Demo Admin','admin' from admin_user
+  on conflict (id) do update set email=excluded.email, full_name=excluded.full_name, role=excluded.role
+  returning id
+), buyer_profile as (
+  insert into public.profiles (id,email,full_name,role)
+  select id,'buyer@example.com','Acme Buyer','customer' from customer_user
+  on conflict (id) do update set email=excluded.email, full_name=excluded.full_name, role=excluded.role
+  returning id
+)
+insert into public.customers (id, owner_id, name, website)
+select '00000000-0000-0000-0000-000000000010', buyer_profile.id, 'Acme Corp', 'https://acme.example'
+from buyer_profile
+on conflict (id) do update set owner_id=excluded.owner_id, name=excluded.name, website=excluded.website;
+
+-- Machines
+insert into public.machines (name, process_code, process_kind, axis_count, rate_per_min, setup_fee, is_active)
+values
+  ('HAAS VF-2SS','cnc_milling','cnc_milling',3,1.2,50,true),
+  ('Hermle C42','cnc_milling','cnc_milling',5,1.6,75,true),
+  ('Mazak Quick Turn','cnc_turning','cnc_turning',2,1.0,40,true),
+  ('Arburg 200T','injection_molding','injection_molding',0,0.03,100,true),
+  ('Buhler Casting Line','casting','casting',0,0.05,200,true)
+on conflict (name) do update set process_code=excluded.process_code;
+
+-- Machine links
+insert into public.machine_materials (machine_id, material_id)
+select m.id, mat.id from public.machines m, public.materials mat
+where m.name in ('HAAS VF-2SS','Hermle C42') and mat.name in ('Aluminum 6061','Stainless Steel 304')
+on conflict do nothing;
+
+insert into public.machine_alloys (machine_id, material_id)
+select m.id, mat.id from public.machines m, public.materials mat
+where m.name='Buhler Casting Line' and mat.name='Zamak 3'
+on conflict do nothing;
+
+insert into public.machine_resins (machine_id, material_id)
+select m.id, mat.id from public.machines m, public.materials mat
+where m.name='Arburg 200T' and mat.name='Nylon 12'
+on conflict do nothing;
+
+insert into public.machine_finishes (machine_id, finish_id)
+select m.id, f.id from public.machines m, public.finishes f
+where (m.name in ('HAAS VF-2SS','Hermle C42') and f.name='Anodized')
+   or (m.name='Mazak Quick Turn' and f.name='Polished')
+   or (m.name='Buhler Casting Line' and f.name='As Cast')
+on conflict do nothing;
+
+-- Capacity for next 30 days
+insert into public.machine_capacity_days (machine_id, day, minutes_available)
+select m.id, (now()::date + s.a) as day, 480
+from public.machines m
+cross join generate_series(0,29) as s(a)
+on conflict do nothing;
+
+-- Part
+insert into public.parts (id, owner_id, customer_id, file_url, file_name, file_ext, size_bytes, process_code)
+values ('00000000-0000-0000-0000-000000000020',
+        (select id from public.profiles where email='buyer@example.com'),
+        '00000000-0000-0000-0000-000000000010',
+        'https://example.com/fixture1.stl','fixture1.stl','stl',123456,'cnc_milling')
+on conflict (id) do update set file_url=excluded.file_url;
+
+-- Quotes
+insert into public.quotes (id, customer_id, created_by, status, region, subtotal, tax, total)
+values
+ ('00000000-0000-0000-0000-000000000030','00000000-0000-0000-0000-000000000010',(select id from public.profiles where email='buyer@example.com'),'draft','us-east',100,7,107),
+ ('00000000-0000-0000-0000-000000000031','00000000-0000-0000-0000-000000000010',(select id from public.profiles where email='buyer@example.com'),'sent','us-east',100,7,107),
+ ('00000000-0000-0000-0000-000000000032','00000000-0000-0000-0000-000000000010',(select id from public.profiles where email='buyer@example.com'),'accepted','us-east',100,7,107)
+on conflict (id) do update set status=excluded.status;
+
+-- Quote items
+insert into public.quote_items (id, quote_id, part_id, process_code, material_id, finish_id, tolerance_id, quantity, unit_price, line_total, machine_id)
+values
+ ('00000000-0000-0000-0000-000000000040','00000000-0000-0000-0000-000000000030','00000000-0000-0000-0000-000000000020','cnc_milling',
+   (select id from public.materials where name='Aluminum 6061'),
+   (select id from public.finishes where name='Anodized'),
+   (select id from public.tolerances where name='Standard' and process_code='cnc_milling'),
+   1,100,100,(select id from public.machines where name='Hermle C42')),
+ ('00000000-0000-0000-0000-000000000041','00000000-0000-0000-0000-000000000031','00000000-0000-0000-0000-000000000020','cnc_turning',
+   (select id from public.materials where name='Stainless Steel 304'),
+   (select id from public.finishes where name='Polished'),
+   (select id from public.tolerances where name='Standard' and process_code='cnc_turning'),
+   1,120,120,(select id from public.machines where name='Mazak Quick Turn')),
+ ('00000000-0000-0000-0000-000000000042','00000000-0000-0000-0000-000000000032','00000000-0000-0000-0000-000000000020','cnc_milling',
+   (select id from public.materials where name='Aluminum 6061'),
+   (select id from public.finishes where name='Anodized'),
+   (select id from public.tolerances where name='High' and process_code='cnc_milling'),
+   1,150,150,(select id from public.machines where name='HAAS VF-2SS'))
+on conflict (id) do update set quote_id=excluded.quote_id;
+
+-- Messages
+insert into public.messages (id, quote_id, sender_id, sender_role, content)
+values
+ ('00000000-0000-0000-0000-000000000060','00000000-0000-0000-0000-000000000032',(select id from public.profiles where email='buyer@example.com'),'customer','Can you expedite this order?'),
+ ('00000000-0000-0000-0000-000000000061','00000000-0000-0000-0000-000000000032',(select id from public.profiles where email='admin@example.com'),'staff','Yes, we can ship in two days.')
+on conflict (id) do update set content=excluded.content;
+
+-- Order
+insert into public.orders (id, quote_id, customer_id, status, total)
+values ('00000000-0000-0000-0000-000000000050','00000000-0000-0000-0000-000000000032','00000000-0000-0000-0000-000000000010','created',107)
+on conflict (id) do update set status=excluded.status;
+
+insert into public.order_items (order_id, quote_item_id, part_id, process_code, quantity, unit_price, line_total)
+values ('00000000-0000-0000-0000-000000000050','00000000-0000-0000-0000-000000000042','00000000-0000-0000-0000-000000000020','cnc_milling',1,150,150)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- add SQL script seeding processes, materials, machines and example quotes/orders
- expand seed script to create demo users, machines with capacity, parts and messages
- provide reset script and documentation for demo data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad66ab0f8083229f987f2f7e03d965