### PR TITLE
chore: add wasm and cad loader support

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,26 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  webpack: (config) => {
+    // Enable async WebAssembly and allow importing .wasm assets
+    config.experiments = {
+      ...(config.experiments || {}),
+      asyncWebAssembly: true,
+    };
+
+    config.module.rules.push({
+      test: /\.wasm$/,
+      type: "asset/resource",
+    });
+
+    // Alias three/examples to three-stdlib for better tree-shaking
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "three/examples/jsm": "three-stdlib",
+    };
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit",
     "verify": "npm run lint && npm run typecheck && npm run build",
     "db:apply": "psql \"$SUPABASE_DB_URL\" -f sql/schema.sql -f sql/policies.sql",
-    "db:seed": "tsx db/seed.ts"
+    "db:seed": "tsx db/seed.ts",
+    "postinstall": "node scripts/postinstall.cjs",
+    "verify:view": "npm run build"
   },
   "dependencies": {
     "@react-three/fiber": "^8.13.5",
@@ -23,7 +25,11 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.49.2",
-    "three": "^0.155.0",
+    "three": "^0.179.1",
+    "three-mesh-bvh": "^0.9.1",
+    "three-stdlib": "^2.36.0",
+    "occt-import-js": "^0.0.23",
+    "dxf-parser": "^1.1.2",
     "uuid": "^9.0.1",
     "zod": "^3.22.4"
   },

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,0 +1,14 @@
+const { copyFileSync, mkdirSync } = require('fs');
+const path = require('path');
+
+const src = path.resolve('node_modules/occt-import-js/dist/occt-import-js.wasm');
+const destDir = path.resolve('public/occt');
+const dest = path.join(destDir, 'occt-import-js.wasm');
+
+try {
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(src, dest);
+  console.log('Copied', src, 'to', dest);
+} catch (err) {
+  console.error('Failed to copy occt-import-js.wasm:', err);
+}


### PR DESCRIPTION
## Summary
- enable async WebAssembly, .wasm assets and tree-shake Three.js loaders in Next.js config
- add Three.js CAD loader dependencies and postinstall script that copies `occt-import-js.wasm`
- include scripts for wasm copy and minimal viewer build

## Testing
- `npm run build` *(fails: You're importing a component that needs useEffect. It only works in a Client Component but none of its parents are marked with "use client")*
- `npm run verify:view` *(fails: You're importing a component that needs useEffect. It only works in a Client Component but none of its parents are marked with "use client")*
- `curl -I http://localhost:3000/occt/occt-import-js.wasm`


------
https://chatgpt.com/codex/tasks/task_e_68ad95385d088322b4db4f717bb31ef9