### PR TITLE
feat: add dfm analysis overlays

### DIFF
--- a/src/components/dfm/DFMPanel.tsx
+++ b/src/components/dfm/DFMPanel.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from "react";
+import type { Suggestion } from "../../lib/dfm/engine";
+
+export interface Alternatives {
+  materials?: string[];
+  tolerances?: string[];
+}
+
+export interface LifetimeEstimate {
+  band: "Low" | "Med" | "High";
+  rationale: string;
+}
+
+interface Props {
+  suggestions: Suggestion[];
+  alternatives?: Alternatives;
+  lifetime?: LifetimeEstimate;
+  onFocusOverlay?: (id: string) => void;
+}
+
+const CATEGORY_LABELS: Record<Suggestion["category"], string> = {
+  feasibility: "Feasibility",
+  manufacturability: "Manufacturability",
+  cost: "Cost",
+  reliability: "Reliability/Lifetime",
+};
+
+export function DFMPanel({
+  suggestions,
+  alternatives,
+  lifetime,
+  onFocusOverlay,
+}: Props) {
+  const grouped = useMemo(() => {
+    const g: Record<string, Suggestion[]> = {};
+    for (const s of suggestions) {
+      (g[s.category] ||= []).push(s);
+    }
+    return g;
+  }, [suggestions]);
+
+  return (
+    <div className="space-y-4 text-sm">
+      {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+        <div key={key}>
+          <h3 className="font-medium text-xs text-gray-600 mb-1">{label}</h3>
+          <ul className="space-y-1">
+            {grouped[key]?.length ? (
+              grouped[key].map((s) => (
+                <li key={s.id}>
+                  <button
+                    className="text-left hover:underline"
+                    onClick={() => s.overlayId && onFocusOverlay?.(s.overlayId)}
+                  >
+                    {s.message}
+                  </button>
+                </li>
+              ))
+            ) : (
+              <li className="text-gray-400">No issues</li>
+            )}
+          </ul>
+        </div>
+      ))}
+
+      {alternatives && (alternatives.materials || alternatives.tolerances) && (
+        <div>
+          <h3 className="font-medium text-xs text-gray-600 mb-1">Alternatives</h3>
+          {alternatives.materials && (
+            <p className="text-xs">Materials: {alternatives.materials.join(", ")}</p>
+          )}
+          {alternatives.tolerances && (
+            <p className="text-xs">Tolerances: {alternatives.tolerances.join(", ")}</p>
+          )}
+        </div>
+      )}
+
+      {lifetime && (
+        <div>
+          <h3 className="font-medium text-xs text-gray-600 mb-1">Lifetime Estimate</h3>
+          <p>
+            <span className="font-semibold mr-1">{lifetime.band}</span>
+            {lifetime.rationale}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DFMPanel;
+

--- a/src/components/dfm/OverlayLegend.tsx
+++ b/src/components/dfm/OverlayLegend.tsx
@@ -1,0 +1,22 @@
+import { severityColorMap } from "../../lib/dfm/overlays";
+import React from "react";
+
+/** Simple legend showing overlay severity colors. */
+export function OverlayLegend() {
+  return (
+    <div className="space-y-1 text-xs">
+      {Object.entries(severityColorMap).map(([sev, color]) => (
+        <div key={sev} className="flex items-center space-x-2">
+          <span
+            className="w-3 h-3 rounded"
+            style={{ background: `#${color.toString(16).padStart(6, "0")}` }}
+          />
+          <span className="capitalize">{sev}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default OverlayLegend;
+

--- a/src/lib/dfm/engine.ts
+++ b/src/lib/dfm/engine.ts
@@ -1,0 +1,153 @@
+import * as THREE from "three";
+import { rules, type RuleResult, type GeometryMetrics } from "./rules";
+import { makeOverlay, type Overlay } from "./overlays";
+import type { Severity } from "./overlays";
+
+export interface AnalyzeParams {
+  mesh?: THREE.Mesh;
+  tris?: Float32Array; // xyz triplets
+  process_kind: string;
+  material?: string;
+  tolerance?: number;
+  certification?: string[];
+  purpose?: string;
+}
+
+export interface Suggestion {
+  id: string;
+  message: string;
+  severity: Severity;
+  category: "feasibility" | "manufacturability" | "cost" | "reliability";
+  metric?: number | string;
+  overlayId?: string;
+}
+
+export interface AnalysisResult {
+  ok: boolean;
+  metrics: GeometryMetrics & { maxOverhang?: number };
+  suggestions: Suggestion[];
+  overlays: Overlay[];
+}
+
+/**
+ * Analyze a geometry against manufacturability rules and return suggestions
+ * and overlay data for visualization.
+ */
+export function analyze(params: AnalyzeParams): AnalysisResult {
+  const geometry = toGeometry(params);
+  const metrics = computeMetrics(geometry);
+
+  const ctxBase = {
+    process_kind: params.process_kind,
+    material: params.material,
+    tolerance: params.tolerance,
+    certification: params.certification,
+    purpose: params.purpose,
+    metrics,
+  };
+
+  const suggestions: Suggestion[] = [];
+  const overlays: Overlay[] = [];
+
+  for (const rule of rules) {
+    if (!rule.applies(ctxBase)) continue;
+    const res: RuleResult | null = rule.evaluate(ctxBase);
+    if (res) {
+      const overlayId = res.overlay ? `${res.id}-overlay` : undefined;
+      if (res.overlay) {
+        overlays.push(makeOverlay(overlayId!, res.overlay, geometry, res.severity));
+      }
+      suggestions.push({
+        id: res.id,
+        message: res.message,
+        severity: res.severity,
+        category: res.category,
+        metric: res.metric,
+        overlayId,
+      });
+    }
+  }
+
+  const ok = suggestions.every((s) => s.severity !== "error");
+  return { ok, metrics, suggestions, overlays };
+}
+
+/** Convert input mesh or triangles into a BufferGeometry */
+function toGeometry(params: AnalyzeParams): THREE.BufferGeometry {
+  if (params.mesh) {
+    return params.mesh.geometry as THREE.BufferGeometry;
+  }
+  if (params.tris) {
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute(
+      "position",
+      new THREE.BufferAttribute(params.tris, 3)
+    );
+    geom.computeVertexNormals();
+    return geom;
+  }
+  throw new Error("analyze requires mesh or tris");
+}
+
+function computeMetrics(geometry: THREE.BufferGeometry): GeometryMetrics & { maxOverhang?: number } {
+  const position = geometry.getAttribute("position") as THREE.BufferAttribute;
+  const bbox = new THREE.Box3().setFromBufferAttribute(position);
+
+  const count = position.count;
+  const thicknessMap = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    const x = position.getX(i);
+    const y = position.getY(i);
+    const z = position.getZ(i);
+    const tx = Math.min(x - bbox.min.x, bbox.max.x - x);
+    const ty = Math.min(y - bbox.min.y, bbox.max.y - y);
+    const tz = Math.min(z - bbox.min.z, bbox.max.z - z);
+    thicknessMap[i] = 2 * Math.min(tx, ty, tz);
+  }
+  const minThickness = thicknessMap.reduce((m, v) => Math.min(m, v), Infinity);
+
+  const overhangFaces: THREE.Vector3[] = [];
+  const index = geometry.getIndex();
+  const threshold = Math.cos((45 * Math.PI) / 180);
+  if (index) {
+    const arr = index.array;
+    for (let i = 0; i < arr.length; i += 3) {
+      const a = arr[i];
+      const b = arr[i + 1];
+      const c = arr[i + 2];
+      const va = new THREE.Vector3(
+        position.getX(a),
+        position.getY(a),
+        position.getZ(a)
+      );
+      const vb = new THREE.Vector3(
+        position.getX(b),
+        position.getY(b),
+        position.getZ(b)
+      );
+      const vc = new THREE.Vector3(
+        position.getX(c),
+        position.getY(c),
+        position.getZ(c)
+      );
+      const normal = new THREE.Vector3()
+        .subVectors(vb, va)
+        .cross(new THREE.Vector3().subVectors(vc, va))
+        .normalize();
+      if (normal.z < threshold) {
+        const center = va.add(vb).add(vc).multiplyScalar(1 / 3);
+        overhangFaces.push(center);
+      }
+    }
+  }
+  const maxOverhang = overhangFaces.length > 0 ? 90 : 0; // placeholder
+
+  return {
+    bbox,
+    thicknessMap,
+    minThickness: isFinite(minThickness) ? minThickness : undefined,
+    overhangFaces,
+    maxOverhang,
+  };
+}
+

--- a/src/lib/dfm/overlays.ts
+++ b/src/lib/dfm/overlays.ts
@@ -1,0 +1,94 @@
+import * as THREE from "three";
+
+export type Severity = "info" | "warning" | "error";
+
+export const severityColorMap: Record<Severity, number> = {
+  info: 0x3b82f6, // blue
+  warning: 0xfbbf24, // amber
+  error: 0xef4444, // red
+};
+
+export type HeatmapSpec = {
+  type: "heatmap";
+  values: Float32Array;
+  threshold: number;
+};
+
+export type ShellSpec = {
+  type: "shell";
+};
+
+export type BBoxSpec = {
+  type: "bbox";
+  box: THREE.Box3;
+};
+
+export type MarkersSpec = {
+  type: "markers";
+  points: THREE.Vector3[];
+};
+
+export type OverlaySpec = HeatmapSpec | ShellSpec | BBoxSpec | MarkersSpec;
+
+export type Overlay = {
+  id: string;
+  type: OverlaySpec["type"];
+  object: THREE.Object3D;
+  severity: Severity;
+};
+
+/** Convert a rule hit overlay spec into a THREE.js object that can be
+ * rendered in a scene. */
+export function makeOverlay(
+  id: string,
+  spec: OverlaySpec,
+  geometry: THREE.BufferGeometry,
+  severity: Severity
+): Overlay {
+  switch (spec.type) {
+    case "heatmap": {
+      const geom = geometry.clone();
+      const count = spec.values.length;
+      const colors = new Float32Array(count * 3);
+      const color = new THREE.Color();
+      for (let i = 0; i < count; i++) {
+        const v = spec.values[i];
+        const t = Math.min(v / spec.threshold, 1);
+        // 0 -> red, 1 -> green (safe)
+        color.setHSL((t * 0.4) / 1.0, 1, 0.5);
+        colors[i * 3] = color.r;
+        colors[i * 3 + 1] = color.g;
+        colors[i * 3 + 2] = color.b;
+      }
+      geom.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+      const mat = new THREE.PointsMaterial({
+        vertexColors: true,
+        size: 2,
+        transparent: true,
+        opacity: 0.8,
+      });
+      return { id, type: "heatmap", object: new THREE.Points(geom, mat), severity };
+    }
+    case "shell": {
+      const edges = new THREE.EdgesGeometry(geometry);
+      const line = new THREE.LineSegments(
+        edges,
+        new THREE.LineBasicMaterial({ color: severityColorMap[severity] })
+      );
+      return { id, type: "shell", object: line, severity };
+    }
+    case "bbox": {
+      const helper = new THREE.Box3Helper(spec.box, severityColorMap[severity]);
+      return { id, type: "bbox", object: helper, severity };
+    }
+    case "markers": {
+      const markerGeom = new THREE.BufferGeometry().setFromPoints(spec.points);
+      const mat = new THREE.PointsMaterial({
+        color: severityColorMap[severity],
+        size: 4,
+      });
+      return { id, type: "markers", object: new THREE.Points(markerGeom, mat), severity };
+    }
+  }
+}
+

--- a/src/lib/dfm/rules.ts
+++ b/src/lib/dfm/rules.ts
@@ -1,0 +1,262 @@
+import * as THREE from "three";
+import type { OverlaySpec } from "./overlays";
+import type { Severity } from "./overlays";
+
+export interface RuleContext {
+  process_kind: string;
+  material?: string;
+  tolerance?: number;
+  certification?: string[];
+  purpose?: string;
+  metrics: GeometryMetrics;
+}
+
+export interface GeometryMetrics {
+  bbox: THREE.Box3;
+  minThickness?: number;
+  thicknessMap?: Float32Array;
+  overhangFaces?: THREE.Vector3[];
+  holeDepthRatio?: number;
+  bossDiameter?: number;
+  bendRadius?: number;
+  thickness?: number;
+  draftAngle?: number;
+  cornerRadius?: number;
+  machiningAllowance?: number;
+}
+
+export interface RuleResult {
+  id: string;
+  message: string;
+  severity: Severity;
+  category: "feasibility" | "manufacturability" | "cost" | "reliability";
+  metric?: number | string;
+  overlay?: OverlaySpec;
+}
+
+export interface Rule {
+  id: string;
+  description: string;
+  applies: (ctx: RuleContext) => boolean;
+  evaluate: (ctx: RuleContext) => RuleResult | null;
+}
+
+const thinWall: Rule = {
+  id: "thin_wall",
+  description: "Wall thickness should exceed process minimums",
+  applies: ({ process_kind }) =>
+    process_kind.startsWith("cnc") || process_kind === "3dp_sls",
+  evaluate: (ctx) => {
+    const { metrics, process_kind } = ctx;
+    if (!metrics.thicknessMap) return null;
+    const threshold = process_kind.startsWith("cnc") ? 0.8 : 1.2;
+    if (metrics.minThickness !== undefined && metrics.minThickness < threshold) {
+      return {
+        id: "thin_wall",
+        message: `Walls thinner than ${threshold}mm detected`,
+        severity: "warning",
+        category: "manufacturability",
+        metric: metrics.minThickness,
+        overlay: {
+          type: "heatmap",
+          values: metrics.thicknessMap,
+          threshold,
+        },
+      };
+    }
+    return null;
+  },
+};
+
+const holeDepth: Rule = {
+  id: "hole_depth_ratio",
+  description: "Hole depth to diameter ratio should not exceed 6:1",
+  applies: ({ process_kind }) => process_kind.startsWith("cnc"),
+  evaluate: ({ metrics }) => {
+    if (metrics.holeDepthRatio !== undefined && metrics.holeDepthRatio > 6) {
+      return {
+        id: "hole_depth_ratio",
+        message: "Hole depth exceeds 6:1 depth-to-diameter ratio",
+        severity: "warning",
+        category: "manufacturability",
+        metric: metrics.holeDepthRatio,
+      };
+    }
+    return null;
+  },
+};
+
+const bossDiameter: Rule = {
+  id: "min_boss_diameter",
+  description: "Boss features require minimum diameters",
+  applies: ({ process_kind }) => process_kind === "injection_molding",
+  evaluate: ({ metrics }) => {
+    if (metrics.bossDiameter !== undefined && metrics.bossDiameter < 1.0) {
+      return {
+        id: "min_boss_diameter",
+        message: "Boss diameter below 1mm may not mold correctly",
+        severity: "error",
+        category: "feasibility",
+        metric: metrics.bossDiameter,
+      };
+    }
+    return null;
+  },
+};
+
+const overhang: Rule = {
+  id: "overhang",
+  description: "Overhangs above 45° require support",
+  applies: ({ process_kind }) => process_kind.startsWith("3dp"),
+  evaluate: ({ metrics }) => {
+    if (metrics.overhangFaces && metrics.overhangFaces.length > 0) {
+      return {
+        id: "overhang",
+        message: ">45° overhangs detected",
+        severity: "warning",
+        category: "manufacturability",
+        overlay: { type: "markers", points: metrics.overhangFaces },
+      };
+    }
+    return null;
+  },
+};
+
+const bendRadius: Rule = {
+  id: "bend_radius",
+  description: "Bend radius should be >= thickness",
+  applies: ({ process_kind }) => process_kind === "sheet_metal",
+  evaluate: ({ metrics }) => {
+    if (
+      metrics.bendRadius !== undefined &&
+      metrics.thickness !== undefined &&
+      metrics.bendRadius < metrics.thickness
+    ) {
+      return {
+        id: "bend_radius",
+        message: "Bend radius should be at least material thickness",
+        severity: "warning",
+        category: "manufacturability",
+        metric: metrics.bendRadius,
+      };
+    }
+    return null;
+  },
+};
+
+const draft: Rule = {
+  id: "draft_required",
+  description: "Draft is required for casting/die processes",
+  applies: ({ process_kind }) =>
+    process_kind === "casting" || process_kind === "die_casting",
+  evaluate: ({ metrics }) => {
+    if (metrics.draftAngle !== undefined && metrics.draftAngle < 1) {
+      return {
+        id: "draft_required",
+        message: "Add at least 1° draft for release",
+        severity: "error",
+        category: "manufacturability",
+        metric: metrics.draftAngle,
+      };
+    }
+    return null;
+  },
+};
+
+const sharpCorners: Rule = {
+  id: "sharp_internal_corners",
+  description: "Internal corners should have fillets",
+  applies: ({ process_kind }) => process_kind.startsWith("cnc"),
+  evaluate: ({ metrics }) => {
+    if (metrics.cornerRadius !== undefined && metrics.cornerRadius < 0.2) {
+      return {
+        id: "sharp_internal_corners",
+        message: "Sharp internal corners may be unmachinable",
+        severity: "warning",
+        category: "manufacturability",
+        metric: metrics.cornerRadius,
+      };
+    }
+    return null;
+  },
+};
+
+const machiningAllowance: Rule = {
+  id: "machining_allowance",
+  description: "Cast parts need machining allowance",
+  applies: ({ process_kind, purpose }) =>
+    process_kind === "casting" && purpose === "machining",
+  evaluate: ({ metrics }) => {
+    if (metrics.machiningAllowance !== undefined && metrics.machiningAllowance < 2) {
+      return {
+        id: "machining_allowance",
+        message: "Add ≥2mm machining allowance to casting",
+        severity: "warning",
+        category: "cost",
+        metric: metrics.machiningAllowance,
+      };
+    }
+    return null;
+  },
+};
+
+const toleranceVsProcess: Rule = {
+  id: "tolerance_vs_process",
+  description: "Requested tolerance may exceed process capability",
+  applies: () => true,
+  evaluate: ({ process_kind, tolerance }) => {
+    if (tolerance === undefined) return null;
+    const capability: Record<string, number> = {
+      cnc_milling: 0.01,
+      cnc_turning: 0.02,
+      injection_molding: 0.05,
+      sheet_metal: 0.1,
+      casting: 0.5,
+      "3dp_sls": 0.2,
+    };
+    const cap = capability[process_kind] ?? 0.1;
+    if (tolerance < cap) {
+      return {
+        id: "tolerance_vs_process",
+        message: "Specified tolerance may drive up cost",
+        severity: "warning",
+        category: "cost",
+        metric: tolerance,
+      };
+    }
+    return null;
+  },
+};
+
+const certification: Rule = {
+  id: "certification_implications",
+  description: "Certain certifications increase process controls",
+  applies: ({ certification }) =>
+    certification !== undefined && certification.length > 0,
+  evaluate: ({ certification }) => {
+    const strict = certification?.some((c) => c === "AS9100" || c === "ITAR");
+    if (strict) {
+      return {
+        id: "certification_implications",
+        message: "Certifications like AS9100/ITAR increase cost and controls",
+        severity: "info",
+        category: "cost",
+      };
+    }
+    return null;
+  },
+};
+
+export const rules: Rule[] = [
+  thinWall,
+  holeDepth,
+  bossDiameter,
+  overhang,
+  bendRadius,
+  draft,
+  sharpCorners,
+  machiningAllowance,
+  toleranceVsProcess,
+  certification,
+];
+


### PR DESCRIPTION
## Summary
- add dfm engine with rule-based analysis and overlay generation
- implement dfm panel with suggestion grouping and alternatives
- render overlay legend with severity colors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find name 'expect')*
- `npm run build` *(fails: importing useState/useEffect in server components)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9549a2cc8322a26637dbca411816