### PR TITLE
feat: add DFM lab page and QAP generation APIs

### DIFF
--- a/src/app/(customer)/dfm/page.tsx
+++ b/src/app/(customer)/dfm/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const ACCEPTED = [
+  ".step",
+  ".stp",
+  ".iges",
+  ".igs",
+  ".stl",
+  ".obj",
+  ".dxf",
+  ".sldprt",
+];
+
+interface Hint {
+  severity: "info" | "warning" | "error";
+  message: string;
+  metric?: number | string;
+}
+
+function CadViewer({ file }: { file: File | null }) {
+  return (
+    <div className="w-full h-64 border rounded flex items-center justify-center bg-gray-50">
+      {file ? <p className="text-sm">{file.name}</p> : <p className="text-sm text-gray-500">No file loaded</p>}
+    </div>
+  );
+}
+
+function DFMPanel({ hints }: { hints: Hint[] }) {
+  if (!hints.length) return null;
+  return (
+    <div className="mt-4 space-y-2">
+      {hints.map((h, i) => (
+        <div
+          key={i}
+          className={`p-2 border-l-4 rounded bg-gray-100 text-sm ${
+            h.severity === "error"
+              ? "border-red-500"
+              : h.severity === "warning"
+              ? "border-yellow-500"
+              : "border-blue-500"
+          }`}
+        >
+          {h.message}
+          {h.metric !== undefined && <span className="ml-1 text-xs">({h.metric})</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DfmPage() {
+  const router = useRouter();
+  const [drag, setDrag] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [partId, setPartId] = useState<string | null>(null);
+  const [material, setMaterial] = useState("aluminum");
+  const [tolerance, setTolerance] = useState("0.005");
+  const [certification, setCertification] = useState("ISO");
+  const [purpose, setPurpose] = useState("");
+  const [hints, setHints] = useState<Hint[]>([]);
+
+  const uploadAndAnalyze = useCallback(
+    async (f: File) => {
+      const ext = f.name.substring(f.name.lastIndexOf(".")).toLowerCase();
+      if (!ACCEPTED.includes(ext)) {
+        alert("Unsupported file type");
+        return;
+      }
+      const initRes = await fetch("/api/upload/part", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filename: f.name }),
+      });
+      if (!initRes.ok) {
+        alert("Upload init failed");
+        return;
+      }
+      const { uploadUrl, part } = await initRes.json();
+      await fetch(uploadUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Type": f.type || "application/octet-stream",
+          "x-upsert": "true",
+        },
+        body: f,
+      });
+      setPartId(part.id);
+      setFile(f);
+    },
+    []
+  );
+
+  useEffect(() => {
+    async function analyze() {
+      if (!partId) return;
+      const res = await fetch("/api/dfm/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ partId, material, tolerance }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setHints(data.hints || []);
+      }
+    }
+    analyze();
+  }, [partId, material, tolerance]);
+
+  const handleDrop = (files: FileList | null) => {
+    const f = files?.[0];
+    if (f) uploadAndAnalyze(f);
+  };
+
+  const generateQap = async () => {
+    if (!partId) return;
+    const res = await fetch("/api/qap/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        partId,
+        material,
+        tolerance,
+        certification,
+        purpose,
+      }),
+    });
+    if (res.ok) {
+      const { qap_id, url } = await res.json();
+      if (url) window.open(url, "_blank");
+      router.push(`/qap/${qap_id}`);
+    }
+  };
+
+  const goToQuote = () => {
+    if (!partId) return;
+    const params = new URLSearchParams({
+      partId,
+      material,
+      tolerance,
+      certification,
+    });
+    router.push(`/instant-quote?${params.toString()}`);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <div className="flex justify-end space-x-2">
+        <button
+          onClick={generateQap}
+          disabled={!partId}
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        >
+          Generate QAP
+        </button>
+        <button
+          onClick={goToQuote}
+          disabled={!partId}
+          className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+        >
+          Create Instant Quote
+        </button>
+      </div>
+
+      <div
+        className={`border-2 border-dashed rounded p-8 text-center cursor-pointer ${
+          drag ? "bg-gray-100" : ""
+        }`}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDrag(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          setDrag(false);
+        }}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDrag(false);
+          handleDrop(e.dataTransfer.files);
+        }}
+      >
+        <input
+          type="file"
+          accept={ACCEPTED.join(",")}
+          className="hidden"
+          id="file-input"
+          onChange={(e) => handleDrop(e.target.files)}
+        />
+        <label htmlFor="file-input" className="block cursor-pointer">
+          <p className="text-gray-600">Drag & drop a CAD file or click to browse</p>
+          <p className="text-xs text-gray-500 mt-2">
+            STEP, IGES, STL, OBJ, DXF, SLDPRT
+          </p>
+        </label>
+      </div>
+
+      <CadViewer file={file} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Material</label>
+          <select
+            value={material}
+            onChange={(e) => setMaterial(e.target.value)}
+            className="w-full border rounded p-2"
+          >
+            <option value="aluminum">Aluminum</option>
+            <option value="steel">Steel</option>
+            <option value="plastic">Plastic</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Tolerance</label>
+          <select
+            value={tolerance}
+            onChange={(e) => setTolerance(e.target.value)}
+            className="w-full border rounded p-2"
+          >
+            <option value="0.010">±0.010"</option>
+            <option value="0.005">±0.005"</option>
+            <option value="0.002">±0.002"</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Certification</label>
+          <select
+            value={certification}
+            onChange={(e) => setCertification(e.target.value)}
+            className="w-full border rounded p-2"
+          >
+            <option value="ISO">ISO</option>
+            <option value="AS9100">AS9100</option>
+            <option value="ITAR">ITAR</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            What is this part for?
+          </label>
+          <textarea
+            value={purpose}
+            onChange={(e) => setPurpose(e.target.value)}
+            className="w-full border rounded p-2"
+            rows={3}
+          />
+        </div>
+      </div>
+
+      <DFMPanel hints={hints} />
+    </div>
+  );
+}
+

--- a/src/app/api/dfm/analyze/route.ts
+++ b/src/app/api/dfm/analyze/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { evaluateDfM } from "@/lib/dfm";
+import { z } from "zod";
+
+const schema = z.object({
+  partId: z.string().uuid().optional(),
+  material: z.string(),
+  tolerance: z.string(),
+});
+
+export async function POST(req: NextRequest) {
+  let body;
+  try {
+    body = schema.parse(await req.json());
+  } catch (err: any) {
+    const message = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const { material, tolerance } = body;
+
+  const geometry: any = {
+    thickness_mm: tolerance === "0.002" ? 0.3 : 1.0,
+    hole_depth_diameter_ratio: material === "steel" ? 4 : 7,
+    max_overhang_deg: material === "plastic" ? 30 : 60,
+  };
+
+  const hints = evaluateDfM("cnc_milling", geometry);
+
+  return NextResponse.json({ hints });
+}

--- a/src/app/api/qap/generate/route.ts
+++ b/src/app/api/qap/generate/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { generateQap } from "@/lib/qap";
+import { createClient } from "@/lib/supabase/server";
+import { randomUUID } from "crypto";
+import { Buffer } from "node:buffer";
+
+const schema = z.object({
+  partId: z.string().uuid(),
+  material: z.string(),
+  tolerance: z.string(),
+  certification: z.string(),
+  purpose: z.string(),
+});
+
+export async function POST(req: NextRequest) {
+  let body;
+  try {
+    body = schema.parse(await req.json());
+  } catch (err: any) {
+    const message = err?.errors?.[0]?.message ?? "Invalid request";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const qap = await generateQap(body);
+  const qapId = randomUUID();
+  const path = `${user.id}/${qapId}.html`;
+
+  await supabase.storage
+    .from("documents")
+    .upload(path, Buffer.from(qap.html, "utf8"), {
+      contentType: "text/html",
+    });
+
+  await supabase.from("documents").insert({
+    id: qapId,
+    owner_id: user.id,
+    part_id: body.partId,
+    type: "qap",
+    file_url: path,
+  });
+
+  const publicUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/documents/${path}`;
+
+  return NextResponse.json({ qap_id: qapId, data: qap, url: publicUrl });
+}

--- a/src/lib/qap.ts
+++ b/src/lib/qap.ts
@@ -1,0 +1,47 @@
+export interface QapInput {
+  partId: string;
+  material: string;
+  tolerance: string;
+  certification: string;
+  purpose: string;
+}
+
+export interface QapData {
+  ctqs: string[];
+  inspection_methods: string[];
+  sampling_plan: string;
+  material_certs: string[];
+  process_controls: string[];
+  html: string;
+}
+
+export async function generateQap(input: QapInput): Promise<QapData> {
+  const ctqs = ["Overall length", "Hole diameter", "Surface finish"];
+  const inspection_methods = ["CMM", "Calipers", "Visual"];
+  const sampling_plan = input.certification === "AS9100" ? "AQL 0.65" : "AQL 1.0";
+  const material_certs = [input.certification];
+  const process_controls = [
+    "First article inspection",
+    "In-process SPC",
+    "Final inspection",
+  ];
+
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8" /><title>QAP</title></head><body><h1>Quality Assurance Plan</h1><h2>CTQs</h2><ul>${ctqs
+    .map((c) => `<li>${c}</li>`)
+    .join("")}</ul><h2>Inspection Methods</h2><ul>${inspection_methods
+    .map((m) => `<li>${m}</li>`)
+    .join("")}</ul><h2>Sampling</h2><p>${sampling_plan}</p><h2>Material Certifications</h2><ul>${material_certs
+    .map((c) => `<li>${c}</li>`)
+    .join("")}</ul><h2>Process Controls</h2><ul>${process_controls
+    .map((c) => `<li>${c}</li>`)
+    .join("")}</ul></body></html>`;
+
+  return {
+    ctqs,
+    inspection_methods,
+    sampling_plan,
+    material_certs,
+    process_controls,
+    html,
+  };
+}


### PR DESCRIPTION
## Summary
- add DFM Lab page with CAD upload, material/tolerance/certification selectors, and actions for QAP or instant quote
- implement DFM analyze API returning hints based on material and tolerance
- add QAP generation library and API that stores HTML output in Supabase

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run typecheck` *(fails: Cannot find name 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_68ad95527f188322a26baa7870e5c889