### PR TITLE
Normalize process kind and make pricing async

### DIFF
--- a/src/app/(customer)/instant-quote/page.tsx
+++ b/src/app/(customer)/instant-quote/page.tsx
@@ -88,7 +88,7 @@ export default function InstantQuotePage({ searchParams }: Props) {
             tolerance={toleranceLabel}
           />
           <p className="text-sm">
-            Unit price: {formatCurrency(price.unit, breakdown.currency as any)}
+            Unit price: {formatCurrency(price.unit_price, breakdown.currency as any)}
           </p>
           <p className="text-lg font-medium">
             Total: {formatCurrency(price.total, breakdown.currency as any)}

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import { calculatePricing } from "@/lib/pricing";
+import { normalizeProcessKind } from "@/lib/process";
 
 interface Props {
   params: { id: string };
@@ -95,8 +96,8 @@ export default async function QuoteDetailPage({ params }: Props) {
       if (rateKey) {
         rateCardForItem[rateKey] = m.rate_per_min;
       }
-      const pricing = calculatePricing({
-        process: item.process_code as any,
+      const pricing = await calculatePricing({
+        process_kind: normalizeProcessKind(item.process_code as string),
         quantity: item.quantity,
         material: material!,
         finish: finish || undefined,

--- a/src/app/api/quotes/reprice/route.ts
+++ b/src/app/api/quotes/reprice/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { calculatePricing } from "@/lib/pricing";
+import { priceItem } from "@/lib/pricing";
+import { normalizeProcessKind } from "@/lib/process";
 import { z } from "zod";
 
 const requestSchema = z.object({
@@ -130,8 +131,9 @@ export async function POST(req: Request) {
       rateCardForItem[rateKey] = ratePerMin;
     }
 
-    const pricing = calculatePricing({
-      process: item.process_code as any,
+    const processKind = normalizeProcessKind(item.process_code as string);
+    const pricing = await priceItem({
+      process_kind: processKind,
       quantity: item.quantity,
       material: material!,
       finish: finish || undefined,
@@ -139,6 +141,9 @@ export async function POST(req: Request) {
       geometry,
       lead_time: leadTime,
       rate_card: rateCardForItem,
+      machines: [],
+      machineMaterials: [],
+      machineFinishes: [],
     });
 
     const setupFee = appliedOverrides.setup_fee ?? machine?.setup_fee ?? 0;

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -1,0 +1,6 @@
+export function normalizeProcessKind(p: string): 'cnc' | 'injection' | 'casting' {
+  if (p === 'cnc' || p === 'cnc_milling' || p === 'cnc_turning') return 'cnc';
+  if (p.startsWith('injection')) return 'injection';
+  if (p === 'casting') return 'casting';
+  throw new Error(`Unknown process kind: ${p}`);
+}


### PR DESCRIPTION
## Summary
- add `normalizeProcessKind` utility to map detailed process codes to core kinds
- expand pricing types and return unit alias while normalizing process kinds internally
- await pricing in API routes and UI components, passing normalized `process_kind` and using `unit_price`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities in dfm page)*
- `npm run typecheck` *(fails: Cannot find name 'describe' in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ada190f570832291d562659495cd0d