### PR TITLE
chore: disable unescaped entities rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['next/core-web-vitals', 'eslint:recommended'],
+  rules: {
+    'react/no-unescaped-entities': 'off',
+  },
+};


### PR DESCRIPTION
## Summary
- add .eslintrc.cjs extending Next core web vitals and eslint:recommended
- disable react/no-unescaped-entities to allow quotes in JSX

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: react/no-unescaped-entities errors)


------
https://chatgpt.com/codex/tasks/task_e_68add15979448322865d405286bd5bb8