### PR TITLE
feat(viewer): harden DXF loader and OCCT typings

### DIFF
--- a/src/components/viewer/loaders/dxf.ts
+++ b/src/components/viewer/loaders/dxf.ts
@@ -1,25 +1,44 @@
 import * as THREE from 'three';
 import DxfParser from 'dxf-parser';
 
+type DxfEntity = { type: string } & (
+  | { type: 'LINE'; start: { x: number; y: number }; end: { x: number; y: number } }
+  | { type: 'LWPOLYLINE'; vertices: { x: number; y: number }[] }
+  | { type: 'POLYLINE'; vertices: { x: number; y: number }[] }
+  | { type: 'CIRCLE'; center: { x: number; y: number }; radius: number }
+  | {
+      type: 'ARC';
+      center: { x: number; y: number };
+      radius: number;
+      startAngle: number;
+      endAngle: number;
+    }
+);
+
 export async function loadDXF(
   url: string
 ): Promise<{ object: THREE.LineSegments; geometry: THREE.BufferGeometry; unit: string }> {
   const res = await fetch(url);
   const text = await res.text();
   const parser = new DxfParser();
-  const dxf = parser.parseSync(text);
+  const dxf: any = parser.parseSync(text);
+  if (!dxf) {
+    throw new Error('Failed to parse DXF');
+  }
 
   const positions: number[] = [];
-  const entities = dxf.entities || [];
+  const entities: DxfEntity[] = (dxf.entities as DxfEntity[]) || [];
 
   for (const e of entities) {
-    if (e.type === 'LINE') {
+    if (e.type === 'LINE' && e.start && e.end) {
       positions.push(e.start.x, e.start.y, 0, e.end.x, e.end.y, 0);
-    } else if (e.type === 'LWPOLYLINE' || e.type === 'POLYLINE') {
-      const verts = e.vertices || [];
-      for (let i = 0; i < verts.length - 1; i++) {
-        const v1 = verts[i];
-        const v2 = verts[i + 1];
+    } else if (
+      (e.type === 'LWPOLYLINE' || e.type === 'POLYLINE') &&
+      Array.isArray(e.vertices)
+    ) {
+      for (let i = 0; i < e.vertices.length - 1; i++) {
+        const v1 = e.vertices[i];
+        const v2 = e.vertices[i + 1];
         positions.push(v1.x, v1.y, 0, v2.x, v2.y, 0);
       }
     }

--- a/src/components/viewer/loaders/obj.ts
+++ b/src/components/viewer/loaders/obj.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
-import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 
 export async function loadOBJ(url: string): Promise<THREE.BufferGeometry> {
   const loader = new OBJLoader();
@@ -16,7 +16,8 @@ export async function loadOBJ(url: string): Promise<THREE.BufferGeometry> {
             geometries.push(geom);
           }
         });
-        const geometry = BufferGeometryUtils.mergeBufferGeometries(geometries, true);
+        const merged = BufferGeometryUtils.mergeBufferGeometries(geometries, true);
+        const geometry = BufferGeometryUtils.mergeVertices(merged);
         geometry.computeVertexNormals();
         resolve(geometry);
       },

--- a/src/components/viewer/loaders/stepIges.ts
+++ b/src/components/viewer/loaders/stepIges.ts
@@ -1,13 +1,5 @@
+/// <reference path='../../../types/occt-import-js.d.ts' />
 import * as THREE from 'three';
-
-// Lazy load the heavy OCCT WASM module only when needed
-let occt: any;
-async function getOCCT() {
-  if (!occt) {
-    occt = await import('occt-import-js');
-  }
-  return occt;
-}
 
 export async function loadStepIges(
   url: string
@@ -17,15 +9,15 @@ export async function loadStepIges(
   const data = new Uint8Array(buffer);
   const ext = url.split('.').pop()?.toLowerCase();
 
-  const occ = await getOCCT();
+  const occt: any = await import('occt-import-js');
   let shape: any;
   if (ext === 'stp' || ext === 'step') {
-    shape = await occ.readStepFile(data);
+    shape = await occt.readStepFile(data);
   } else {
-    shape = await occ.readIgesFile(data);
+    shape = await occt.readIgesFile(data);
   }
 
-  const mesh = await occ.tessellate(shape, { deflection: 0.1 });
+  const mesh = await occt.tessellate(shape, { deflection: 0.1 });
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute(mesh.vertices, 3));
   if (mesh.normals) {

--- a/src/types/occt-import-js.d.ts
+++ b/src/types/occt-import-js.d.ts
@@ -1,0 +1,4 @@
+declare module 'occt-import-js' {
+  const mod: any;
+  export = mod;
+}


### PR DESCRIPTION
## Summary
- strengthen DXF loader with entity type guards and null parsing check
- fix BufferGeometryUtils import and merge vertices in OBJ loader
- dynamically load OCCT WASM with ambient module declaration

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: best.warnings is possibly undefined)*
- `npm run test:unit` *(fails: mockClient is not defined; missing fixture files)*

------
https://chatgpt.com/codex/tasks/task_e_68add7717e7c8322ae9907673b636c88