### PR TITLE
feat: make cookies async for Next 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:apply": "psql \"$SUPABASE_DB_URL\" -f sql/schema.sql -f sql/policies.sql",
     "db:seed": "tsx db/seed.ts",
     "postinstall": "node scripts/postinstall.cjs",
-    "verify:view": "npm run build"
+    "verify:view": "npm run build",
+    "codemod:cookies": "node --experimental-modules scripts/codemods/next15-cookies.mjs"
   },
   "dependencies": {
     "@react-three/fiber": "^8.13.5",

--- a/scripts/codemods/next15-cookies.mjs
+++ b/scripts/codemods/next15-cookies.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import { globSync } from 'glob';
+
+const files = globSync('src/**/*.{ts,tsx}', { nodir: true });
+for (const f of files) {
+  let s = fs.readFileSync(f, 'utf8');
+  if (!/from ["']next\/headers["']/.test(s)) continue;
+  if (!s.includes('cookies()')) continue;
+  if (!s.includes("from '@/lib/next/cookies")) {
+    s = s.replace(/from ["']next\/headers["'];?/g, (m) => `${m}\nimport { cookiesAsync } from '@/lib/next/cookies';`);
+  }
+  // Add await cookiesAsync() in common patterns
+  s = s.replace(/const\s+([a-zA-Z_][\w]*)\s*=\s*cookies\(\)/g, 'const $1 = await cookiesAsync()');
+  // If top-level await might be illegal in this file, developer will move into async fn. We keep it simple.
+  fs.writeFileSync(f, s);
+  console.log('patched', f);
+}

--- a/src/app/(customer)/account/page.tsx
+++ b/src/app/(customer)/account/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 
 export default async function AccountPage() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -19,7 +19,7 @@ export default async function AccountPage() {
 
   async function updateProfile(formData: FormData) {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -34,7 +34,7 @@ export default async function AccountPage() {
 
   async function updateCompany(formData: FormData) {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -56,7 +56,7 @@ export default async function AccountPage() {
 
   async function updateAddress(formData: FormData) {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -82,7 +82,7 @@ export default async function AccountPage() {
 
   async function updatePrefs(formData: FormData) {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/src/app/(customer)/dashboard/page.tsx
+++ b/src/app/(customer)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 
 export default async function DashboardPage() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/(customer)/forms/[formId]/page.tsx
+++ b/src/app/(customer)/forms/[formId]/page.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export default async function FormPage({ params }: Props) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: form } = await supabase
     .from("custom_forms")
     .select("id,name,description,schema")
@@ -15,7 +15,7 @@ export default async function FormPage({ params }: Props) {
 
   async function submit(formData: FormData) {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/src/app/(customer)/order/[id]/page.tsx
+++ b/src/app/(customer)/order/[id]/page.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 export default async function OrderPage({ params }: Props) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: order } = await supabase
     .from("orders")
     .select("id,status,total,created_at,order_items(id,part_id,quantity,line_total)")

--- a/src/app/(customer)/orders/page.tsx
+++ b/src/app/(customer)/orders/page.tsx
@@ -7,7 +7,7 @@ interface Props {
 const PAGE_SIZE = 10;
 
 export default async function OrdersPage({ searchParams }: Props) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/(customer)/parts/page.tsx
+++ b/src/app/(customer)/parts/page.tsx
@@ -7,7 +7,7 @@ interface Props {
 const PAGE_SIZE = 10;
 
 export default async function PartsPage({ searchParams }: Props) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/(customer)/quote/[id]/page.tsx
+++ b/src/app/(customer)/quote/[id]/page.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export default async function QuotePage({ params }: Props) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: quote } = await supabase
     .from("quotes")
     .select("id,total,currency,quote_items(pricing_breakdown,process_code,lead_time_days)")

--- a/src/app/(customer)/quote/[id]/share/page.tsx
+++ b/src/app/(customer)/quote/[id]/share/page.tsx
@@ -13,7 +13,7 @@ export default async function ShareQuotePage({ params, searchParams }: Props) {
     notFound();
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: share } = await supabase
     .from("quote_share_tokens")
     .select("quote_id,expires_at")

--- a/src/app/admin/abandoned/page.tsx
+++ b/src/app/admin/abandoned/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function AbandonedAdminPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: abandoned } = await supabase
     .from("abandoned_quotes")
     .select("id,email,created_at")
@@ -12,7 +12,7 @@ export default async function AbandonedAdminPage() {
   async function convert(formData: FormData) {
     "use server";
     const id = formData.get("id") as string;
-    const supabase = createClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("abandoned_quotes")
       .select("email")

--- a/src/app/admin/customers/[id]/page.tsx
+++ b/src/app/admin/customers/[id]/page.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default async function CustomerDetailPage({ params }: Props) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: customer } = await supabase
     .from("customers")
     .select("*")
@@ -18,7 +18,7 @@ export default async function CustomerDetailPage({ params }: Props) {
     "use server";
     const name = formData.get("name") as string;
     const notes = formData.get("notes") as string;
-    const supabase = createClient();
+    const supabase = await createClient();
     await supabase
       .from("customers")
       .update({ name, notes })

--- a/src/app/admin/customers/page.tsx
+++ b/src/app/admin/customers/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function CustomersAdminPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: customers } = await supabase
     .from("customers")
     .select("id,name,created_at")

--- a/src/app/admin/machines/[id]/page.tsx
+++ b/src/app/admin/machines/[id]/page.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default async function MachineDetailPage({ params }: Props) {
   await requireAdmin();
-  const supabase = createServerClient();
+  const supabase = await createServerClient();
   const { data: machine } = await supabase
     .from("machines")
     .select("*")

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default async function OrderDetailPage({ params }: Props) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: order } = await supabase
     .from("orders")
     .select("*")

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -3,7 +3,7 @@ import { requireAdmin } from "@/lib/auth";
 
 export default async function AdminOrdersPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: orders } = await supabase
     .from("orders")
     .select("id,status,total,created_at")

--- a/src/app/admin/parts/page.tsx
+++ b/src/app/admin/parts/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function AdminPartsPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: parts } = await supabase
     .from("parts")
     .select("id,file_name,owner_id,created_at")

--- a/src/app/admin/payments/page.tsx
+++ b/src/app/admin/payments/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function PaymentsAdminPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: payments } = await supabase
     .from("payments")
     .select("id,provider,amount,status,created_at")

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default async function QuoteDetailPage({ params }: Props) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: quote } = await supabase
     .from("quotes")
     .select("*")
@@ -147,7 +147,7 @@ export default async function QuoteDetailPage({ params }: Props) {
 
   async function acceptQuote() {
     "use server";
-    const supabase = createClient();
+    const supabase = await createClient();
     await supabase.from("quotes").update({ status: "accepted" }).eq("id", params.id);
     await fetch(`${origin}/api/orders`, {
       method: "POST",

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function UsersAdminPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: users } = await supabase
     .from("profiles")
     .select("id,full_name,email,role")
@@ -13,7 +13,7 @@ export default async function UsersAdminPage() {
     "use server";
     const userId = formData.get("user_id") as string;
     const role = formData.get("role") as string;
-    const supabase = createClient();
+    const supabase = await createClient();
     await supabase.from("profiles").update({ role }).eq("id", userId);
   }
 

--- a/src/app/admin/vendors/[id]/page.tsx
+++ b/src/app/admin/vendors/[id]/page.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default async function VendorDetailPage({ params }: Props) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: vendor } = await supabase
     .from("profiles")
     .select("id,full_name,email,role")

--- a/src/app/admin/vendors/page.tsx
+++ b/src/app/admin/vendors/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export default async function VendorsAdminPage() {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: vendors } = await supabase
     .from("profiles")
     .select("id,full_name,email")
@@ -13,7 +13,7 @@ export default async function VendorsAdminPage() {
   async function assignVendor(formData: FormData) {
     "use server";
     const userId = formData.get("user_id") as string;
-    const supabase = createClient();
+    const supabase = await createClient();
     await supabase.from("profiles").update({ role: "vendor" }).eq("id", userId);
   }
 

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
     const message = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: message }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/auth/first-login/route.ts
+++ b/src/app/api/auth/first-login/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { createServerClient } from '@supabase/ssr'
 import type { User } from '@supabase/supabase-js'
 import { createAdminClient } from '@/lib/supabase/admin'
+import { cookiesAsync } from '@/lib/next/cookies'
 
 async function ensureProfile(user: User) {
   const supabaseAdmin = createAdminClient()
@@ -14,7 +14,7 @@ async function ensureProfile(user: User) {
 }
 
 export async function POST() {
-  const cookieStore = cookies()
+  const cookieStore = await cookiesAsync()
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !anonKey) {

--- a/src/app/api/capacity/available/route.ts
+++ b/src/app/api/capacity/available/route.ts
@@ -13,7 +13,7 @@ const querySchema = z.object({
 
 // Provides upcoming available capacity dates for a machine.
 export async function GET(req: NextRequest) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: auth } = await supabase.auth.getUser();
   if (!auth.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/capacity/days/route.ts
+++ b/src/app/api/capacity/days/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: Request) {
   }
   const start = new Date(`${month}-01`);
   const end = endOfMonth(start);
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("capacity_days")
     .select("*")
@@ -53,7 +53,7 @@ export async function POST(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("capacity_days")
     .upsert(
@@ -82,7 +82,7 @@ export async function PATCH(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: existing, error: exErr } = await supabase
     .from("capacity_days")
     .select("minutes_available, minutes_reserved")

--- a/src/app/api/capacity/reserve/route.ts
+++ b/src/app/api/capacity/reserve/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: msg }, { status: 400 });
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: existing, error: exErr } = await supabase
     .from("machine_capacity_days")
     .select("minutes_available, minutes_reserved")

--- a/src/app/api/certifications/route.ts
+++ b/src/app/api/certifications/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: Request) {
   const page = parseInt(searchParams.get("page") || "0", 10);
   const filterKey = searchParams.get("filterKey") || "name";
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   let query = supabase
     .from("certifications")
     .select("*", { count: "exact" })
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("certifications")
     .insert(body)
@@ -69,7 +69,7 @@ export async function PUT(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("certifications")
     .update(body)
@@ -89,7 +89,7 @@ export async function DELETE(req: Request) {
   if (!id) {
     return NextResponse.json({ error: "id required" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("certifications")
     .delete()

--- a/src/app/api/machines/[id]/alloys/route.ts
+++ b/src/app/api/machines/[id]/alloys/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, count, error } = await supabase
     .from("machine_alloys")
     .select(
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_alloys")
     .insert({ ...body, machine_id: params.id })
@@ -73,7 +73,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_alloys")
     .update(body)
@@ -96,7 +96,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("machine_alloys")
     .delete()

--- a/src/app/api/machines/[id]/finishes/route.ts
+++ b/src/app/api/machines/[id]/finishes/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, count, error } = await supabase
     .from("machine_finishes")
     .select("id, finish_id, finish_rate_multiplier, is_active, finishes(name)", {
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_finishes")
     .insert({ ...body, machine_id: params.id })
@@ -70,7 +70,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_finishes")
     .update(body)
@@ -91,7 +91,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("machine_finishes")
     .delete()

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, count, error } = await supabase
     .from("machine_materials")
     .select("id, material_id, material_rate_multiplier, is_active, materials(name)", {
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_materials")
     .insert({ ...body, machine_id: params.id })
@@ -70,7 +70,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_materials")
     .update(body)
@@ -91,7 +91,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("machine_materials")
     .delete()

--- a/src/app/api/machines/[id]/resins/route.ts
+++ b/src/app/api/machines/[id]/resins/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, count, error } = await supabase
     .from("machine_resins")
     .select(
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_resins")
     .insert({ ...body, machine_id: params.id })
@@ -73,7 +73,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_resins")
     .update(body)
@@ -96,7 +96,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("machine_resins")
     .delete()

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -25,7 +25,7 @@ interface Params {
 
 export async function GET(_req: NextRequest, { params }: Params) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machines")
     .select("*")
@@ -46,7 +46,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machines")
     .update(body)
@@ -61,7 +61,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
 
 export async function DELETE(_req: NextRequest, { params }: Params) {
   await requireAdmin();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase.from("machines").delete().eq("id", params.id);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/machines/route.ts
+++ b/src/app/api/machines/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "0", 10);
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, count, error } = await supabase
     .from("machines")
     .select("*", { count: "exact" })
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machines")
     .insert(body)

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -7,7 +7,7 @@ const requestSchema = z.object({
 });
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/parts/geometry/route.ts
+++ b/src/app/api/parts/geometry/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: msg }, { status: 400 });
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/parts/geometry/step/route.ts
+++ b/src/app/api/parts/geometry/step/route.ts
@@ -4,7 +4,7 @@ import { stepRequestSchema, StepRequest } from "@/lib/validators/step";
 import { maxProjectedArea } from "@/lib/geometry/projectedArea";
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/parts/geometry/stl/route.ts
+++ b/src/app/api/parts/geometry/stl/route.ts
@@ -8,7 +8,7 @@ const MAX_FILE_SIZE = 150 * 1024 * 1024; // 150MB
 const ALLOWED_TYPES = ['application/octet-stream', 'model/stl'];
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/pricing/simulate/route.ts
+++ b/src/app/api/pricing/simulate/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
 
   const process_kind = normalizeProcessKind(body.process);
 
-  const supabase = createClient();
+  const supabase = await createClient();
 
   let material = (
     await supabase

--- a/src/app/api/qap/generate/route.ts
+++ b/src/app/api/qap/generate/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/quotes/reprice/route.ts
+++ b/src/app/api/quotes/reprice/route.ts
@@ -18,7 +18,7 @@ const requestSchema = z.object({
 });
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/quotes/request/route.ts
+++ b/src/app/api/quotes/request/route.ts
@@ -7,7 +7,7 @@ const schema = z.object({
 });
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -17,7 +17,7 @@ const requestSchema = z.object({
 });
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/quotes/share/route.ts
+++ b/src/app/api/quotes/share/route.ts
@@ -9,7 +9,7 @@ const schema = z.object({
 });
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/upload/part/route.ts
+++ b/src/app/api/upload/part/route.ts
@@ -6,7 +6,7 @@ import { createSignedUploadUrl } from "@/lib/storage";
 import { uploadPartSchema } from "@/lib/validators/upload";
 
 export async function POST(req: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/api/vendor-certifications/route.ts
+++ b/src/app/api/vendor-certifications/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
   const page = parseInt(searchParams.get("page") || "0", 10);
   const filterKey = searchParams.get("filterKey") || "profiles.full_name";
   const PAGE_SIZE = 10;
-  const supabase = createClient();
+  const supabase = await createClient();
   let query = supabase
     .from("vendor_certifications")
     .select("*, profiles(full_name), certifications(name)", { count: "exact" })
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("vendor_certifications")
     .insert(body)
@@ -70,7 +70,7 @@ export async function PUT(req: Request) {
     const msg = err?.errors?.[0]?.message ?? "Invalid request";
     return NextResponse.json({ error: msg }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("vendor_certifications")
     .update(body)
@@ -90,7 +90,7 @@ export async function DELETE(req: Request) {
   if (!id) {
     return NextResponse.json({ error: "id required" }, { status: 400 });
   }
-  const supabase = createClient();
+  const supabase = await createClient();
   const { error } = await supabase
     .from("vendor_certifications")
     .delete()

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: Request) {
   }
   const { code } = parsed.data
 
-  const supabase = createClient()
+  const supabase = await createClient()
 
   if (code) {
     await supabase.auth.exchangeCodeForSession(code)

--- a/src/components/viewer/CadViewer.tsx
+++ b/src/components/viewer/CadViewer.tsx
@@ -38,7 +38,7 @@ export function CadViewer({
 
   useEffect(() => {
     if (!fileUrl) return;
-    const ext = fileName.split('.').pop()?.toLowerCase();
+    const ext = (fileName.split('.').pop() || '').toLowerCase();
     if (!ext) return;
     if (ext === 'sldprt') {
       setSldprt(true);

--- a/src/components/viewer/loaders/obj.ts
+++ b/src/components/viewer/loaders/obj.ts
@@ -16,7 +16,7 @@ export async function loadOBJ(url: string): Promise<THREE.BufferGeometry> {
             geometries.push(geom);
           }
         });
-        const merged = BufferGeometryUtils.mergeBufferGeometries(geometries, true);
+        const merged = BufferGeometryUtils.mergeGeometries(geometries, true);
         const geometry = BufferGeometryUtils.mergeVertices(merged);
         geometry.computeVertexNormals();
         resolve(geometry);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "./supabase/server";
 
 export async function requireAuth() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -16,7 +16,7 @@ export async function requireAuth() {
 
 export async function requireAdmin() {
   const session = await requireAuth();
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data } = await supabase
     .from("profiles")
     .select("role")

--- a/src/lib/capacity.ts
+++ b/src/lib/capacity.ts
@@ -38,7 +38,7 @@ export async function earliestSlot({
 }: EarliestSlotArgs): Promise<{ date: string; minutes: number } | null> {
   const start = startDate ? new Date(startDate) : new Date();
   const end = addDays(start, maxDays);
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_capacity_days")
     .select("day, minutes_available, minutes_reserved")

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,7 +1,7 @@
 import { createClient } from "./supabase/server";
 
 export async function getKpis() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const now = new Date();
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(now.getDate() - 30);
@@ -53,7 +53,7 @@ export async function getKpis() {
 }
 
 export async function getFeeds() {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   const [messagesRes, uploadsRes, workloadRes] = await Promise.all([
     supabase

--- a/src/lib/next/cookies.ts
+++ b/src/lib/next/cookies.ts
@@ -1,0 +1,17 @@
+import { cookies as nextCookies, headers as nextHeaders } from 'next/headers';
+
+export type CookieStore = Awaited<ReturnType<typeof nextCookies>>;
+export async function cookiesAsync(): Promise<CookieStore> {
+  const c = nextCookies() as any;
+  return typeof c?.then === 'function' ? await c : c;
+}
+
+export async function getCookie(name: string): Promise<string | undefined> {
+  const store = await cookiesAsync();
+  return store.get(name)?.value;
+}
+
+export async function headersAsync(): Promise<Awaited<ReturnType<typeof nextHeaders>>> {
+  const h = nextHeaders() as any;
+  return typeof h?.then === 'function' ? await h : h;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { cookiesAsync } from '@/lib/next/cookies';
 
-export function createClient() {
-  const cookieStore = cookies();
+export async function createClient() {
+  const cookieStore = await cookiesAsync();
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !anonKey) {

--- a/tests/unit/capacity.spec.ts
+++ b/tests/unit/capacity.spec.ts
@@ -1,6 +1,29 @@
 import { minutesNeededForItem, earliestSlot } from '../../src/lib/capacity';
 import { vi } from 'vitest';
 
+vi.mock('../../src/lib/supabase/server', () => {
+  const order = vi.fn().mockResolvedValue({
+    data: [
+      { day: '2024-01-01', minutes_available: 480, minutes_reserved: 470 },
+      { day: '2024-01-02', minutes_available: 480, minutes_reserved: 480 },
+      { day: '2024-01-03', minutes_available: 480, minutes_reserved: 100 },
+    ],
+    error: null,
+  });
+  const mockClient = {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            lte: vi.fn().mockReturnValue({ order }),
+          }),
+        }),
+      }),
+    }),
+  } as any;
+  return { createClient: () => mockClient };
+});
+
 describe('capacity utilities', () => {
   it('extracts reserved minutes from item', () => {
     expect(minutesNeededForItem({ capacity_minutes_reserved: 30 })).toBe(30);
@@ -9,26 +32,6 @@ describe('capacity utilities', () => {
   });
 
   it('finds earliest slot with available capacity', async () => {
-    const order = vi.fn().mockResolvedValue({
-      data: [
-        { day: '2024-01-01', minutes_available: 480, minutes_reserved: 470 },
-        { day: '2024-01-02', minutes_available: 480, minutes_reserved: 480 },
-        { day: '2024-01-03', minutes_available: 480, minutes_reserved: 100 },
-      ],
-      error: null,
-    });
-    const mockClient = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            gte: vi.fn().mockReturnValue({
-              lte: vi.fn().mockReturnValue({ order }),
-            }),
-          }),
-        }),
-      }),
-    } as any;
-    vi.mock('../../src/lib/supabase/server', () => ({ createClient: () => mockClient }));
     const res = await earliestSlot({ machineId: 'm1', minutesRequired: 100, startDate: new Date('2024-01-01'), maxDays: 5 });
     expect(res).toEqual({ date: '2024-01-03', minutes: 380 });
     vi.restoreAllMocks();


### PR DESCRIPTION
## Summary
- add async wrappers for `cookies`/`headers` and codemod to migrate usage
- await Supabase client creation and update all server call sites
- fix type issues in viewer utilities and adjust unit test mocks

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68adde6dfba48322b1a64071a5e11075