### PR TITLE
feat: force node runtime for api routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:seed": "tsx db/seed.ts",
     "postinstall": "node scripts/postinstall.cjs",
     "verify:view": "npm run build",
-    "codemod:cookies": "node --experimental-modules scripts/codemods/next15-cookies.mjs"
+    "codemod:cookies": "node --experimental-modules scripts/codemods/next15-cookies.mjs",
+    "codemod:runtime": "node scripts/codemods/add-node-runtime.mjs"
   },
   "dependencies": {
     "@react-three/fiber": "^8.13.5",

--- a/scripts/codemods/add-node-runtime.mjs
+++ b/scripts/codemods/add-node-runtime.mjs
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'glob';
+
+const files = globSync('src/app/api/**/route.{ts,tsx}', { nodir: true, windowsPathsNoEscape: true });
+for (const f of files) {
+  let s = fs.readFileSync(f, 'utf8');
+  if (/export\s+const\s+runtime\s*=\s*['\"](edge|nodejs)['\"]/m.test(s)) {
+    // already declares runtime
+  } else {
+    s = `export const runtime = 'nodejs'\n` + s;
+    fs.writeFileSync(f, s);
+    console.log('patched runtime=nodejs ->', f);
+  }
+}

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";

--- a/src/app/api/auth/first-login/route.ts
+++ b/src/app/api/auth/first-login/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
 import type { User } from '@supabase/supabase-js'

--- a/src/app/api/capacity/available/route.ts
+++ b/src/app/api/capacity/available/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { addDays } from "date-fns";
 import { z } from "zod";

--- a/src/app/api/capacity/days/route.ts
+++ b/src/app/api/capacity/days/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/capacity/reserve/route.ts
+++ b/src/app/api/capacity/reserve/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/certifications/route.ts
+++ b/src/app/api/certifications/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/dfm/analyze/route.ts
+++ b/src/app/api/dfm/analyze/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { evaluateDfM } from "@/lib/dfm";
 import { z } from "zod";

--- a/src/app/api/machines/[id]/alloys/route.ts
+++ b/src/app/api/machines/[id]/alloys/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/machines/[id]/finishes/route.ts
+++ b/src/app/api/machines/[id]/finishes/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/machines/[id]/resins/route.ts
+++ b/src/app/api/machines/[id]/resins/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/machines/route.ts
+++ b/src/app/api/machines/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { z } from "zod";

--- a/src/app/api/parts/geometry/route.ts
+++ b/src/app/api/parts/geometry/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { z } from "zod";

--- a/src/app/api/parts/geometry/step/route.ts
+++ b/src/app/api/parts/geometry/step/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { stepRequestSchema, StepRequest } from "@/lib/validators/step";

--- a/src/app/api/parts/geometry/stl/route.ts
+++ b/src/app/api/parts/geometry/stl/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';

--- a/src/app/api/pricing/simulate/route.ts
+++ b/src/app/api/pricing/simulate/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/qap/generate/route.ts
+++ b/src/app/api/qap/generate/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { generateQap } from "@/lib/qap";

--- a/src/app/api/quotes/reprice/route.ts
+++ b/src/app/api/quotes/reprice/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { priceItem } from "@/lib/pricing";

--- a/src/app/api/quotes/request/route.ts
+++ b/src/app/api/quotes/request/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/quotes/share/route.ts
+++ b/src/app/api/quotes/share/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { randomBytes } from "crypto";

--- a/src/app/api/upload/part/route.ts
+++ b/src/app/api/upload/part/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import path from "path";
 import { randomUUID } from "crypto";

--- a/src/app/api/vendor-certifications/route.ts
+++ b/src/app/api/vendor-certifications/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs'
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";


### PR DESCRIPTION
## Summary
- add codemod to inject `runtime = 'nodejs'` into API routes
- register codemod script in package.json and run it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit`
- `npx next build --no-lint` *(fails: Failed to patch lockfile: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68ade7cf0b2483229b7b3b17f1fbffb3