### PR TITLE
chore: skip build-time eslint

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   webpack: (config) => {
     // Enable async WebAssembly and allow importing .wasm assets
     config.experiments = {


### PR DESCRIPTION
## Summary
- disable Next.js build-time ESLint

## Testing
- `NEXT_SKIP_LOCKFILE_PATCH=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ade7d8616c8322b37b76442bc72b63