### PR TITLE
chore: enforce node runtime for Supabase files

### DIFF
--- a/src/app/(customer)/account/page.tsx
+++ b/src/app/(customer)/account/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 
 export default async function AccountPage() {

--- a/src/app/(customer)/dashboard/page.tsx
+++ b/src/app/(customer)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 
 export default async function DashboardPage() {

--- a/src/app/(customer)/forms/[formId]/page.tsx
+++ b/src/app/(customer)/forms/[formId]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAuth } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 

--- a/src/app/(customer)/order/[id]/page.tsx
+++ b/src/app/(customer)/order/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 
 interface Props {

--- a/src/app/(customer)/parts/page.tsx
+++ b/src/app/(customer)/parts/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 
 interface Props {

--- a/src/app/(customer)/quote/[id]/page.tsx
+++ b/src/app/(customer)/quote/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import PriceExplainerModal from "@/components/quotes/PriceExplainerModal";

--- a/src/app/(customer)/quote/[id]/share/page.tsx
+++ b/src/app/(customer)/quote/[id]/share/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 

--- a/src/app/admin/abandoned/page.tsx
+++ b/src/app/admin/abandoned/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/capacity/page.tsx
+++ b/src/app/admin/capacity/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import CapacityClient from './CapacityClient';

--- a/src/app/admin/certifications/page.tsx
+++ b/src/app/admin/certifications/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import CertificationsClient from './CertificationsClient';

--- a/src/app/admin/customers/[id]/page.tsx
+++ b/src/app/admin/customers/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/customers/page.tsx
+++ b/src/app/admin/customers/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/finishes/page.tsx
+++ b/src/app/admin/finishes/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import FinishesClient from './FinishesClient';

--- a/src/app/admin/machines/[id]/page.tsx
+++ b/src/app/admin/machines/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import MachineDetailClient from './MachineDetailClient';

--- a/src/app/admin/machines/page.tsx
+++ b/src/app/admin/machines/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import MachinesClient from './MachinesClient';

--- a/src/app/admin/materials/page.tsx
+++ b/src/app/admin/materials/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import MaterialsClient from './MaterialsClient';

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 import { requireAdmin } from "@/lib/auth";
 

--- a/src/app/admin/parts/page.tsx
+++ b/src/app/admin/parts/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/payments/page.tsx
+++ b/src/app/admin/payments/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import { calculatePricing } from "@/lib/pricing";

--- a/src/app/admin/tolerances/page.tsx
+++ b/src/app/admin/tolerances/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from '@/lib/auth';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import TolerancesClient from './TolerancesClient';

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/vendors/[id]/page.tsx
+++ b/src/app/admin/vendors/[id]/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/admin/vendors/page.tsx
+++ b/src/app/admin/vendors/page.tsx
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'


### PR DESCRIPTION
## Summary
- declare `export const runtime = "nodejs"` atop all Supabase-importing pages and routes to force Node execution

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build` *(fails: Type 'Props' does not satisfy the constraint 'PageProps')*


------
https://chatgpt.com/codex/tasks/task_e_68adffd8fb548322a25efe4581ba0ef2