### PR TITLE
chore: update API routes for Node runtime and Next 15

### DIFF
--- a/scripts/codemods/add-node-runtime.mjs
+++ b/scripts/codemods/add-node-runtime.mjs
@@ -10,14 +10,10 @@ const files = globSync('src/app/api/**/route.{ts,tsx}', {
 
 for (const f of files) {
   let s = fs.readFileSync(f, 'utf8');
-
-  // Detect an existing runtime export (edge or nodejs)
   const hasRuntime = /(^|\n)\s*export\s+const\s+runtime\s*=\s*['"](edge|nodejs)['"]/.test(s);
-
   if (!hasRuntime) {
     s = "export const runtime = 'nodejs'\n" + s;
     fs.writeFileSync(f, s, 'utf8');
-    // eslint-disable-next-line no-console
     console.log('patched runtime=nodejs ->', f);
   }
 }

--- a/scripts/codemods/route-ctx-to-params.mjs
+++ b/scripts/codemods/route-ctx-to-params.mjs
@@ -1,0 +1,25 @@
+/* eslint-env node */
+import fs from 'node:fs';
+import { globSync } from 'glob';
+
+// Rewrite "(req: Request, ctx: Ctx)" or similar to Next 15 compatible: (req: Request, context: { params: Record<string,string> })
+const files = globSync('src/app/api/**/route.{ts,tsx}', { nodir: true, windowsPathsNoEscape: true });
+
+for (const f of files) {
+  let s = fs.readFileSync(f, 'utf8');
+
+  // 1) Replace common custom type aliases for context (Ctx, Context, RouteCtx...)
+  s = s.replace(/\(([^)]*?)\bctx\s*:\s*([A-Za-z_][\w]*)\b([^)]*?)\)/g, '( $1context: { params: Record<string,string> }$3 )');
+
+  // 2) Replace any other second-arg names pointing to non-standard types
+  s = s.replace(/export\s+async\s+function\s+(GET|POST|PATCH|PUT|DELETE)\s*\(\s*([^,]+),\s*[^)]+\)\s*\{/g,
+                 'export async function $1($2, context: { params: Record<string,string> }) {');
+
+  // 3) Add minimal import for NextResponse if responses used but import missing
+  if (/NextResponse\.json\(/.test(s) && !/from 'next\/server'/.test(s)) {
+    s = "import { NextResponse } from 'next/server'\n" + s;
+  }
+
+  fs.writeFileSync(f, s, 'utf8');
+  console.log('normalized route signature ->', f);
+}

--- a/src/app/api/capacity/days/route.ts
+++ b/src/app/api/capacity/days/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/capacity/reserve/route.ts
+++ b/src/app/api/capacity/reserve/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/certifications/route.ts
+++ b/src/app/api/certifications/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/machines/[id]/alloys/route.ts
+++ b/src/app/api/machines/[id]/alloys/route.ts
@@ -1,11 +1,10 @@
-export const runtime = "nodejs";
-import { NextResponse } from "next/server";
+export const runtime = 'nodejs'
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 
-type Ctx = { params: { id: string } };
-
 /** Link an alloy to this machine (POST) and list alloys (GET) */
-export async function GET(_req: Request, { params }: Ctx) {
+export async function GET(_req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_alloys")
@@ -16,7 +15,8 @@ export async function GET(_req: Request, { params }: Ctx) {
   return NextResponse.json(data);
 }
 
-export async function POST(req: Request, { params }: Ctx) {
+export async function POST(req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const body = await req.json(); // { material_id, alloy_rate_multiplier? }
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -33,7 +33,8 @@ export async function POST(req: Request, { params }: Ctx) {
   return NextResponse.json(data, { status: 201 });
 }
 
-export async function DELETE(req: Request, { params }: Ctx) {
+export async function DELETE(req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const { material_id } = await req.json();
   const supabase = await createClient();
   const { error } = await supabase

--- a/src/app/api/machines/[id]/finishes/route.ts
+++ b/src/app/api/machines/[id]/finishes/route.ts
@@ -10,11 +10,8 @@ const schema = z.object({
   is_active: z.boolean().optional(),
 });
 
-interface Params {
-  params: { id: string };
-}
-
-export async function GET(req: NextRequest, { params }: Params) {
+export async function GET(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const search = searchParams.get("search") || "";
@@ -36,7 +33,8 @@ export async function GET(req: NextRequest, { params }: Params) {
   return NextResponse.json({ data, count });
 }
 
-export async function POST(req: NextRequest, { params }: Params) {
+export async function POST(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   let body;
   try {
@@ -57,7 +55,8 @@ export async function POST(req: NextRequest, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function PUT(req: NextRequest, { params }: Params) {
+export async function PUT(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
@@ -85,7 +84,8 @@ export async function PUT(req: NextRequest, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function DELETE(req: NextRequest, { params }: Params) {
+export async function DELETE(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
@@ -103,4 +103,3 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   return NextResponse.json({ ok: true });
 }
-

--- a/src/app/api/machines/[id]/materials/route.ts
+++ b/src/app/api/machines/[id]/materials/route.ts
@@ -10,11 +10,8 @@ const schema = z.object({
   is_active: z.boolean().optional(),
 });
 
-interface Params {
-  params: { id: string };
-}
-
-export async function GET(req: NextRequest, { params }: Params) {
+export async function GET(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const search = searchParams.get("search") || "";
@@ -36,7 +33,8 @@ export async function GET(req: NextRequest, { params }: Params) {
   return NextResponse.json({ data, count });
 }
 
-export async function POST(req: NextRequest, { params }: Params) {
+export async function POST(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   let body;
   try {
@@ -57,7 +55,8 @@ export async function POST(req: NextRequest, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function PUT(req: NextRequest, { params }: Params) {
+export async function PUT(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
@@ -85,7 +84,8 @@ export async function PUT(req: NextRequest, { params }: Params) {
   return NextResponse.json(data);
 }
 
-export async function DELETE(req: NextRequest, { params }: Params) {
+export async function DELETE(req: NextRequest, context: { params: Record<string,string> }) {
+  const { params } = context;
   await requireAdmin();
   const searchParams = req.nextUrl.searchParams;
   const id = searchParams.get("id");
@@ -103,4 +103,3 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
   return NextResponse.json({ ok: true });
 }
-

--- a/src/app/api/machines/[id]/resins/route.ts
+++ b/src/app/api/machines/[id]/resins/route.ts
@@ -1,11 +1,10 @@
-export const runtime = "nodejs";
-import { NextResponse } from "next/server";
+export const runtime = 'nodejs'
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 
-type Ctx = { params: { id: string } };
-
 /** Link a resin to this machine (POST) and list resins (GET) */
-export async function GET(_req: Request, { params }: Ctx) {
+export async function GET(_req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("machine_resins")
@@ -16,7 +15,8 @@ export async function GET(_req: Request, { params }: Ctx) {
   return NextResponse.json(data);
 }
 
-export async function POST(req: Request, { params }: Ctx) {
+export async function POST(req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const body = await req.json(); // { material_id, resin_rate_multiplier? }
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -33,7 +33,8 @@ export async function POST(req: Request, { params }: Ctx) {
   return NextResponse.json(data, { status: 201 });
 }
 
-export async function DELETE(req: Request, { params }: Ctx) {
+export async function DELETE(req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const { material_id } = await req.json();
   const supabase = await createClient();
   const { error } = await supabase

--- a/src/app/api/machines/[id]/route.ts
+++ b/src/app/api/machines/[id]/route.ts
@@ -1,10 +1,9 @@
-export const runtime = "nodejs";
-import { NextResponse } from "next/server";
+export const runtime = 'nodejs'
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 
-type Ctx = { params: { id: string } };
-
-export async function GET(_req: Request, { params }: Ctx) {
+export async function GET(_req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("machines")
@@ -16,7 +15,8 @@ export async function GET(_req: Request, { params }: Ctx) {
   return NextResponse.json(data);
 }
 
-export async function PATCH(req: Request, { params }: Ctx) {
+export async function PATCH(req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const payload = await req.json();
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -30,7 +30,8 @@ export async function PATCH(req: Request, { params }: Ctx) {
   return NextResponse.json(data);
 }
 
-export async function DELETE(_req: Request, { params }: Ctx) {
+export async function DELETE(_req: Request, context: { params: Record<string,string> }) {
+  const { params } = context;
   const supabase = await createClient();
   const { error } = await supabase.from("machines").delete().eq("id", params.id);
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 import { z } from "zod";
 

--- a/src/app/api/parts/geometry/route.ts
+++ b/src/app/api/parts/geometry/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 import { z } from "zod";
 import { POST as postSTL } from "./stl/route";

--- a/src/app/api/parts/geometry/step/route.ts
+++ b/src/app/api/parts/geometry/step/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 import { stepRequestSchema, StepRequest } from "@/lib/validators/step";
 import { maxProjectedArea } from "@/lib/geometry/projectedArea";

--- a/src/app/api/quotes/reprice/route.ts
+++ b/src/app/api/quotes/reprice/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 import { priceItem } from "@/lib/pricing";
 import { normalizeProcessKind } from "@/lib/process";

--- a/src/app/api/quotes/request/route.ts
+++ b/src/app/api/quotes/request/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { priceItem } from "@/lib/pricing";

--- a/src/app/api/quotes/share/route.ts
+++ b/src/app/api/quotes/share/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { createClient } from "@/lib/supabase/server";
 import { randomBytes } from "crypto";
 import { z } from "zod";

--- a/src/app/api/upload/part/route.ts
+++ b/src/app/api/upload/part/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import path from "path";
 import { randomUUID } from "crypto";
 import { createClient } from "@/lib/supabase/server";

--- a/src/app/api/vendor-certifications/route.ts
+++ b/src/app/api/vendor-certifications/route.ts
@@ -1,5 +1,5 @@
 export const runtime = 'nodejs'
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";


### PR DESCRIPTION
## Summary
- add codemods to normalize route handler context and enforce Node runtime
- update App Router API routes to use Node.js runtime and Next 15-compatible handler signatures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae19dee02c83229d7ba379bc4474b3