### PR TITLE
refactor: update alloys API for Next15

### DIFF
--- a/src/app/api/machines/[id]/alloys/route.ts
+++ b/src/app/api/machines/[id]/alloys/route.ts
@@ -1,47 +1,64 @@
-export const runtime = "nodejs";
-import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+export const runtime = 'nodejs';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@/lib/supabase/server';
 
-type Ctx = { params: { id: string } };
+const ParamsSchema = z.object({ id: z.string().min(1) });
+const BodySchema = z.object({
+  material_id: z.string().uuid(),
+  alloy_rate_multiplier: z.number().min(0.1).max(10).optional()
+});
 
-/** Link an alloy to this machine (POST) and list alloys (GET) */
+type Ctx = { params: Promise<{ id: string }> };
+
 export async function GET(_req: Request, { params }: Ctx) {
+  const p = ParamsSchema.safeParse(await params);
+  if (!p.success) return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
   const supabase = await createClient();
   const { data, error } = await supabase
-    .from("machine_alloys")
-    .select("id, material_id, alloy_rate_multiplier")
-    .eq("machine_id", params.id);
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json(data);
+    .from('machine_alloys')
+    .select('id, material_id, alloy_rate_multiplier')
+    .eq('machine_id', p.data.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: data ?? [] });
 }
 
 export async function POST(req: Request, { params }: Ctx) {
-  const body = await req.json(); // { material_id, alloy_rate_multiplier? }
+  const p = ParamsSchema.safeParse(await params);
+  if (!p.success) return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
+  const json = await req.json().catch(() => null);
+  const b = BodySchema.safeParse(json);
+  if (!b.success) return NextResponse.json({ error: b.error.flatten() }, { status: 400 });
   const supabase = await createClient();
   const { data, error } = await supabase
-    .from("machine_alloys")
-    .insert({
-      machine_id: params.id,
-      material_id: body.material_id,
-      alloy_rate_multiplier: body.alloy_rate_multiplier ?? 1.0,
-    })
-    .select("*")
+    .from('machine_alloys')
+    .upsert(
+      {
+        machine_id: p.data.id,
+        material_id: b.data.material_id,
+        alloy_rate_multiplier: b.data.alloy_rate_multiplier ?? 1
+      },
+      { onConflict: 'machine_id,material_id' }
+    )
+    .select()
     .single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json(data, { status: 201 });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data }, { status: 201 });
 }
 
 export async function DELETE(req: Request, { params }: Ctx) {
-  const { material_id } = await req.json();
+  const p = ParamsSchema.safeParse(await params);
+  if (!p.success) return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
+  const { searchParams } = new URL(req.url);
+  const material_id = searchParams.get('material_id') || undefined;
+  if (!material_id) return NextResponse.json({ error: 'material_id required' }, { status: 400 });
   const supabase = await createClient();
   const { error } = await supabase
-    .from("machine_alloys")
+    .from('machine_alloys')
     .delete()
-    .eq("machine_id", params.id)
-    .eq("material_id", material_id);
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+    .eq('machine_id', p.data.id)
+    .eq('material_id', material_id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ ok: true });
 }
+


### PR DESCRIPTION
## Summary
- refactor machine alloy link route for Next.js 15 context shape
- add Zod validation and Supabase upsert logic for POST
- support DELETE query param and consistent error responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68ae19e66ba8832293c0aba171ad2e3a