### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: verify
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/seovimalraj/instant-quote/security/code-scanning/1](https://github.com/seovimalraj/instant-quote/security/code-scanning/1)

To fix the problem, add a `permissions:` block specifying least-privilege for the workflow or job. The minimal permission required for most `verify` or CI workflows is `contents: read`, which allows read access to the repository code and metadata. Add the following block either at the workflow root (before `jobs:` to apply to all jobs), or within the specific job definition if fine-grained control is needed. Since just one job is present, applying at the root keeps things simple and clear. 

You only need to edit the `.github/workflows/verify.yml` file. Insert the following block after the `name:` key and before the `on:` key:
```yaml
permissions:
  contents: read
```
This change will restrict the GITHUB_TOKEN for this workflow to read-only on repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
