### PR TITLE
feat(auth): add Supabase server/browser helpers compatible with Next 15 cookies

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,13 +1,10 @@
-import { createBrowserClient } from "@supabase/ssr";
+'use client';
+import { createBrowserClient } from '@supabase/ssr';
 
 export function createClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anonKey) {
-    return {
-      auth: { getUser: async () => ({ data: { user: null }, error: null }) },
-      from: () => ({ select: async () => ({ data: null, error: new Error("Supabase env missing") }) })
-    } as any;
-  }
-  return createBrowserClient(url, anonKey);
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
 }
+


### PR DESCRIPTION
## Summary
- replace Supabase server helper to use async cookies in Next 15
- add lightweight browser client factory

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aea6cfd91c8322ac17900713669ccd