### PR TITLE
feat(auth): add public sign-in & sign-up pages and SignOutButton

### DIFF
--- a/src/app/(public)/signin/page.tsx
+++ b/src/app/(public)/signin/page.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-export default function SignUpPage() {
+export default function SignInPage() {
   const r = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPw] = useState('');
@@ -12,21 +12,21 @@ export default function SignUpPage() {
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setBusy(true); setErr(null);
-    const res = await fetch('/api/auth/signup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
+    const res = await fetch('/api/auth/signin', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
     setBusy(false);
-    if (!res.ok) { const j = await res.json().catch(()=>({})); setErr(j.error || 'Sign up failed'); return; }
-    r.push('/signin');
+    if (!res.ok) { const j = await res.json().catch(()=>({})); setErr(j.error || 'Login failed'); return; }
+    r.push('/admin');
   }
 
   return (
     <div className="min-h-screen grid place-items-center p-6">
       <form onSubmit={onSubmit} className="w-full max-w-sm space-y-3 border p-5 rounded-xl">
-        <h1 className="text-xl font-semibold">Create account</h1>
+        <h1 className="text-xl font-semibold">Sign in</h1>
         <input className="border w-full px-3 py-2 rounded" placeholder="you@company.com" value={email} onChange={e=>setEmail(e.target.value)} />
-        <input className="border w-full px-3 py-2 rounded" type="password" placeholder="Min 6 chars" value={password} onChange={e=>setPw(e.target.value)} />
+        <input className="border w-full px-3 py-2 rounded" type="password" placeholder="••••••••" value={password} onChange={e=>setPw(e.target.value)} />
         {err && <div className="text-red-600 text-sm">{err}</div>}
-        <button disabled={busy} className="bg-black text-white px-3 py-2 rounded w-full">{busy? 'Creating…':'Sign up'}</button>
-        <p className="text-sm">Have an account? <a href="/signin" className="text-blue-600 underline">Sign in</a></p>
+        <button disabled={busy} className="bg-black text-white px-3 py-2 rounded w-full">{busy? 'Signing in…':'Sign in'}</button>
+        <p className="text-sm">No account? <a href="/signup" className="text-blue-600 underline">Create one</a></p>
       </form>
     </div>
   );

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,0 +1,11 @@
+'use client';
+export function SignOutButton() {
+  return (
+    <button
+      className="text-sm px-3 py-2 border rounded"
+      onClick={async () => { await fetch('/api/auth/signout', { method: 'POST' }); window.location.href = '/signin'; }}
+    >
+      Sign out
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add minimal sign-in page that posts credentials to `/api/auth/signin`
- add minimal sign-up page that posts credentials to `/api/auth/signup`
- provide `SignOutButton` that calls `/api/auth/signout`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`
- `npm run dev` (start & stop)


------
https://chatgpt.com/codex/tasks/task_e_68aea6e1054c83228f44db88544c4e11