### PR TITLE
Make all App Router API routes use Node runtime

### DIFF
--- a/scripts/codemods/add-node-runtime.mjs
+++ b/scripts/codemods/add-node-runtime.mjs
@@ -2,18 +2,14 @@
 import fs from 'node:fs';
 import { globSync } from 'glob';
 
-// Ensure all App Router API routes run on Node.js runtime (avoids Edge + Supabase warnings)
-const files = globSync('src/app/api/**/route.{ts,tsx}', {
-  nodir: true,
-  windowsPathsNoEscape: true,
-});
+const files = globSync('src/app/api/**/route.{ts,tsx}', { nodir: true, windowsPathsNoEscape: true });
 
 for (const f of files) {
   let s = fs.readFileSync(f, 'utf8');
-  const hasRuntime = /(^|\n)\s*export\s+const\s+runtime\s*=\s*['"](edge|nodejs)['"]/.test(s);
+  const hasRuntime = /(^|\n)\s*export\s+const\s+runtime\s*=\s*['"](edge|nodejs)['"]/m.test(s);
   if (!hasRuntime) {
     s = "export const runtime = 'nodejs'\n" + s;
-    fs.writeFileSync(f, s, 'utf8');
+    fs.writeFileSync(f, s);
     console.log('patched runtime=nodejs ->', f);
   }
 }


### PR DESCRIPTION
## Summary
- ensure App Router API routes use the Node.js runtime by checking and injecting `export const runtime = 'nodejs'`

## Testing
- `node scripts/codemods/add-node-runtime.mjs`
- `npm run verify:strict`


------
https://chatgpt.com/codex/tasks/task_e_68aea6f60b8483228d5093e3c287e432