### PR TITLE
feat: add repository audit script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log*
 
 # output
 out
+tmp


### PR DESCRIPTION
## Summary
- add diagnostics script to audit Next.js routes, features, and line counts
- ignore tmp output directory

## Testing
- `node -v`
- `npm ci --no-audit --prefer-offline --silent`
- `node scripts/diagnostics.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68aeb05013d0832297ebf9015ab3cd41