### PR TITLE
Fix Next.js Link lint errors and remove unused eslint-disable

### DIFF
--- a/scripts/codemods/fix-links-and-eslint.mjs
+++ b/scripts/codemods/fix-links-and-eslint.mjs
@@ -1,0 +1,64 @@
+/* eslint-env node */
+/* eslint-disable no-useless-escape */
+import fs from 'node:fs';
+import path from 'node:path';
+
+function ensureFile(p) {
+  if (!fs.existsSync(p)) {
+    console.error('File not found:', p);
+    process.exit(1);
+  }
+}
+
+// 1) Fix <a href="/admin/..."> usage in admin layout to use <Link />
+(function fixAdminLayout() {
+  const file = 'src/app/admin/layout.tsx';
+  if (!fs.existsSync(file)) return; // skip if project variant lacks admin layout
+  let s = fs.readFileSync(file, 'utf8');
+
+  // Add import Link from 'next/link' if missing
+  if (!/from[\s\n]+['\"]next\/link['\"]/.test(s)) {
+    if (/^'use client'/.test(s) || /^"use client"/.test(s)) {
+      s = s.replace(/^(?:'use client'|"use client")[^\n]*\n?/, m => m + "import Link from 'next/link'\n");
+    } else if (/^import\s/m.test(s)) {
+      // insert after last import
+      const idx = s.lastIndexOf('\nimport ');
+      const insertAt = idx >= 0 ? s.indexOf('\n', idx) + 1 : 0;
+      s = s.slice(0, insertAt) + "import Link from 'next/link'\n" + s.slice(insertAt);
+    } else {
+      s = "import Link from 'next/link'\n" + s;
+    }
+  }
+
+  // Transform specific internal anchors to Link while preserving attributes
+  const toLink = (route) => {
+    const hrefRe = new RegExp(`<a\\s+([^>]*?)href=[\"\']${route}[\"\']([^>]*)>`, 'gi');
+    s = s.replace(hrefRe, (_m, pre, post) => `<Link href="${route}" ${pre}${post}>`);
+  };
+
+  toLink('/admin/machines/');
+  toLink('/admin/machines');
+  toLink('/admin/quotes/');
+  toLink('/admin/quotes');
+
+  // Cautiously switch closing tags where appropriate.
+  // If file contains Link import, it's likely safe in this layout to replace </a> with </Link>
+  s = s.replace(/<\/a>/g, '</Link>');
+
+  fs.writeFileSync(file, s);
+  console.log('Patched', file);
+})();
+
+// 2) Remove unused eslint-disable for no-img-element in instant-quote page
+(function fixUnusedDisable() {
+  const file = 'src/app/(customer)/instant-quote/page.tsx';
+  if (!fs.existsSync(file)) return;
+  let s = fs.readFileSync(file, 'utf8');
+  const before = s;
+  s = s.replace(/\/\*\s*eslint-disable\s+@next\/next\/no-img-element\s*\*\//g, '');
+  s = s.replace(/\/\/\s*eslint-disable-next-line\s+@next\/next\/no-img-element.*\n/g, '');
+  if (s !== before) {
+    fs.writeFileSync(file, s);
+    console.log('Removed unused eslint-disable in', file);
+  }
+})();

--- a/src/app/(customer)/instant-quote/page.tsx
+++ b/src/app/(customer)/instant-quote/page.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable @next/next/no-img-element */
+
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import InstantQuoteForm from "@/components/quotes/InstantQuoteForm";
 import PriceExplainerModal, { BreakdownJson } from "@/components/quotes/PriceExplainerModal";
 import Badges from "@/components/quotes/Badges";
@@ -11,6 +11,14 @@ import { formatCurrency } from "@/components/quotes/BreakdownRow";
 import { LeadTime, normalizeLeadTime } from "@/lib/uiTypes";
 
 export default function InstantQuotePage() {
+  return (
+    <Suspense>
+      <InstantQuotePageContent />
+    </Suspense>
+  );
+}
+
+function InstantQuotePageContent() {
   const router = useRouter();
   const sp = useSearchParams();
 

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -6,8 +6,11 @@ import { createClient } from '@/lib/supabase/client'
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [message, setMessage] = useState('')
-  const next = new URLSearchParams(window.location.search).get('next')
-  const redirectTo = `${window.location.origin}/auth/callback${next ? `?next=${encodeURIComponent(next)}` : ''}`
+
+  const getRedirectTo = () => {
+    const next = new URLSearchParams(window.location.search).get('next')
+    return `${window.location.origin}/auth/callback${next ? `?next=${encodeURIComponent(next)}` : ''}`
+  }
 
   const handleEmailSignIn = async (e: FormEvent) => {
     e.preventDefault()
@@ -16,7 +19,7 @@ export default function LoginPage() {
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: redirectTo,
+        emailRedirectTo: getRedirectTo(),
         shouldCreateUser: false,
       },
     })
@@ -29,7 +32,7 @@ export default function LoginPage() {
     await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo,
+        redirectTo: getRedirectTo(),
       },
     })
   }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 import '@/styles/globals.css';
 import { requireAdmin } from '@/lib/auth';
+import Link from 'next/link';
 import { SignOutButton } from '@/components/SignOutButton';
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
@@ -12,13 +13,27 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <span>Admin</span>
           </div>
           <nav className="space-y-2 text-sm">
-            <a className="block" href="/admin">Dashboard</a>
-            <a className="block" href="/admin/machines">Machines</a>
-            <a className="block" href="/admin/materials">Materials</a>
-            <a className="block" href="/admin/finishes">Finishes</a>
-            <a className="block" href="/admin/tolerances">Tolerances</a>
-            <a className="block" href="/admin/quotes">Quotes</a>
-            <a className="block" href="/admin/capacity">Capacity</a>
+            <Link className="block" href="/admin">
+              Dashboard
+            </Link>
+            <Link href="/admin/machines" className="block">
+              Machines
+            </Link>
+            <Link className="block" href="/admin/materials">
+              Materials
+            </Link>
+            <Link className="block" href="/admin/finishes">
+              Finishes
+            </Link>
+            <Link className="block" href="/admin/tolerances">
+              Tolerances
+            </Link>
+            <Link href="/admin/quotes" className="block">
+              Quotes
+            </Link>
+            <Link className="block" href="/admin/capacity">
+              Capacity
+            </Link>
           </nav>
           <div className="mt-6"><SignOutButton/></div>
         </aside>


### PR DESCRIPTION
## Summary
- add codemod to replace admin layout anchors with Next.js `Link` and clean an unused eslint-disable
- replace admin navigation anchors with `Link` components
- wrap instant quote page in `Suspense` and compute login redirects lazily to satisfy build

## Testing
- `npm run verify:strict`


------
https://chatgpt.com/codex/tasks/task_e_68aeb915be748322ab7fb3dd6d6c2abb