### PR TITLE
Customer shell layout (public site) to mirror TailAdmin styling

### DIFF
--- a/src/app/(customer)/layout.tsx
+++ b/src/app/(customer)/layout.tsx
@@ -1,0 +1,5 @@
+import SiteShell from '@/components/site/SiteShell';
+import '@/styles/globals.css';
+export default function CustomerLayout({ children }: { children: React.ReactNode }) {
+  return <SiteShell>{children}</SiteShell>;
+}

--- a/src/components/site/SiteShell.tsx
+++ b/src/components/site/SiteShell.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+export default function SiteShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen">
+      <header className="bg-white border-b">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-4">
+          <Link href="/" className="text-lg font-semibold">Frigate</Link>
+          <nav className="ml-auto flex items-center gap-3 text-sm">
+            <Link href="/instant-quote" className="link">Instant Quote</Link>
+            <Link href="/parts" className="link">My Parts</Link>
+            <Link href="/orders" className="btn">Orders</Link>
+            <Link href="/signin" className="btn btn-primary">Sign in</Link>
+          </nav>
+        </div>
+      </header>
+      <main className="max-w-7xl mx-auto p-4 md:p-6">{children}</main>
+      <footer className="py-6 text-center text-sm text-slate-500">© {new Date().getFullYear()} Frigate</footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SiteShell component providing TailAdmin-like header, nav, and footer for public pages
- wrap customer routes with new SiteShell via layout component

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec11f357c8322ada7fec9dba7dd17