### PR TITLE
Add Admin UI atoms (StatCard, SectionCard)

### DIFF
--- a/src/components/admin/ui/SectionCard.tsx
+++ b/src/components/admin/ui/SectionCard.tsx
@@ -1,0 +1,11 @@
+export default function SectionCard({ title, actions, children }: { title: string; actions?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="card">
+      <div className="px-4 py-3 border-b flex items-center justify-between">
+        <div className="font-medium">{title}</div>
+        <div className="flex items-center gap-2">{actions}</div>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}

--- a/src/components/admin/ui/StatCard.tsx
+++ b/src/components/admin/ui/StatCard.tsx
@@ -1,0 +1,37 @@
+import { type ElementType } from 'react';
+
+export default function StatCard({
+  title,
+  value,
+  subtext,
+  icon: Icon,
+  trend
+}: {
+  title: string;
+  value: string | number;
+  subtext?: string;
+  icon?: ElementType;
+  trend?: { dir: 'up' | 'down'; value: string };
+}) {
+  return (
+    <div className="card p-4 flex items-start gap-3">
+      {Icon ? (
+        <div className="h-10 w-10 rounded-xl bg-brand-50 text-brand-700 flex items-center justify-center">
+          <Icon className="h-5 w-5" />
+        </div>
+      ) : null}
+      <div className="flex-1">
+        <div className="text-sm text-slate-600">{title}</div>
+        <div className="text-2xl font-semibold leading-tight">{value}</div>
+        <div className="text-xs text-slate-500 mt-1 flex items-center gap-2">
+          {trend ? (
+            <span className={trend.dir === 'up' ? 'text-emerald-600' : 'text-rose-600'}>
+              {trend.dir === 'up' ? '▲' : '▼'} {trend.value}
+            </span>
+          ) : null}
+          {subtext ? <span>{subtext}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add StatCard component with optional icon, trend indicator, and subtext for admin dashboards
- introduce SectionCard wrapper for titled sections with optional actions area

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68aec47fee6c832285e5e3babd40fd43