### PR TITLE
Add admin layout components

### DIFF
--- a/src/components/admin/AdminBreadcrumb.tsx
+++ b/src/components/admin/AdminBreadcrumb.tsx
@@ -1,0 +1,32 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const LABELS: Record<string,string> = {
+  admin: 'Dashboard', machines: 'Machines', materials: 'Materials', quotes: 'Quotes', orders: 'Orders', customers: 'Customers', settings: 'Settings'
+};
+
+function toLabel(seg: string) { return LABELS[seg] || seg.charAt(0).toUpperCase() + seg.slice(1); }
+
+export default function AdminBreadcrumb() {
+  const pathname = usePathname() || '/admin';
+  const segs = pathname.split('/').filter(Boolean);
+  const trail = segs.slice(1); // drop leading 'admin'
+  return (
+    <nav className="text-sm text-slate-600">
+      <ol className="flex items-center gap-2">
+        <li><Link href="/admin" className="link">Admin</Link></li>
+        {trail.map((s, i) => (
+          <li key={i} className="flex items-center gap-2">
+            <span>/</span>
+            {i === trail.length - 1 ? (
+              <span className="text-slate-900">{toLabel(s)}</span>
+            ) : (
+              <Link href={`/${segs.slice(0, i + 2).join('/')}`} className="link">{toLabel(s)}</Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { Search } from 'lucide-react';
+import AdminBreadcrumb from './AdminBreadcrumb';
+import { SignOutButton } from '@/components/auth/SignOutButton';
+
+export default function AdminHeader() {
+  return (
+    <header className="card p-4 flex items-center gap-3">
+      <div className="flex-1 min-w-0">
+        <AdminBreadcrumb />
+      </div>
+      <div className="hidden md:flex items-center gap-2">
+        <div className="relative">
+          <Search className="h-4 w-4 absolute left-3 top-2.5 text-slate-400" />
+          <input placeholder="Search" className="pl-9 pr-3 py-2 rounded-xl border text-sm" />
+        </div>
+        <SignOutButton />
+      </div>
+    </header>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,0 +1,47 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, Cog, Layers, FileText, ShoppingCart, Users, Settings } from 'lucide-react';
+
+const NAV = [
+  { group: 'Overview', items: [ { href: '/admin', label: 'Dashboard', icon: LayoutDashboard } ] },
+  { group: 'Operations', items: [
+      { href: '/admin/machines', label: 'Machines', icon: Cog },
+      { href: '/admin/materials', label: 'Materials', icon: Layers }
+    ]
+  },
+  { group: 'Sales', items: [
+      { href: '/admin/quotes', label: 'Quotes', icon: FileText },
+      { href: '/admin/orders', label: 'Orders', icon: ShoppingCart },
+      { href: '/admin/customers', label: 'Customers', icon: Users, disabled: true }
+    ]
+  },
+  { group: 'Settings', items: [ { href: '/admin/settings', label: 'Settings', icon: Settings, disabled: true } ] }
+];
+
+export default function AdminSidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="hidden md:block col-span-3 lg:col-span-2 p-4 space-y-5 bg-white border-r">
+      <div className="px-2 text-lg font-semibold">Admin</div>
+      {NAV.map((g) => (
+        <div key={g.group} className="space-y-2">
+          <div className="px-2 text-xs uppercase tracking-wide text-slate-500">{g.group}</div>
+          <nav className="space-y-1">
+            {g.items.map((n) => {
+              const active = pathname?.startsWith(n.href);
+              const C = n.icon as any;
+              const cls = n.disabled ? 'opacity-50 pointer-events-none' : active ? 'bg-brand-50 text-brand-700' : 'hover:bg-slate-50';
+              return (
+                <Link key={n.href} href={n.href} className={`flex items-center gap-2 px-3 py-2 rounded-xl ${cls}`}>
+                  {C ? <C className="h-4 w-4"/> : null}
+                  <span>{n.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      ))}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AdminBreadcrumb` for path-based navigation context
- add `AdminSidebar` with grouped navigation and active state highlighting
- add `AdminHeader` featuring breadcrumb trail, search field, and sign-out button

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aec48d74a883228d183675539b769d