### PR TITLE
Add rich Admin dashboard page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,50 @@
+import StatCard from '@/components/admin/ui/StatCard';
+import SectionCard from '@/components/admin/ui/SectionCard';
+import { LayoutDashboard, FileText, ShoppingCart, Layers } from 'lucide-react';
+import Link from 'next/link';
+
 export default function AdminDashboard() {
+  const recent = [
+    { id: 'Q-1007', customer: 'Acme Corp', amount: 1210, status: 'Sent', created: '2025-08-20' },
+    { id: 'Q-1006', customer: 'Starline', amount: 860, status: 'Draft', created: '2025-08-19' },
+    { id: 'Q-1005', customer: 'BlueSteel', amount: 3120, status: 'Accepted', created: '2025-08-18' }
+  ];
+
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      <div className="card p-4"><div className="text-sm text-slate-600">Quotes (24h)</div><div className="text-2xl font-semibold">12</div></div>
-      <div className="card p-4"><div className="text-sm text-slate-600">Orders</div><div className="text-2xl font-semibold">7</div></div>
-      <div className="card p-4"><div className="text-sm text-slate-600">Revenue</div><div className="text-2xl font-semibold">$3,420</div></div>
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Quotes (24h)" value={12} subtext="vs. 9 yesterday" icon={FileText} trend={{ dir: 'up', value: '33%' }} />
+        <StatCard title="Orders" value={7} subtext="open" icon={ShoppingCart} trend={{ dir: 'up', value: '8%' }} />
+        <StatCard title="Revenue" value="$3,420" subtext="last 7d" icon={LayoutDashboard} trend={{ dir: 'down', value: '5%' }} />
+        <StatCard title="Materials" value={24} subtext="active" icon={Layers} />
+      </div>
+
+      <SectionCard title="Recent Quotes" actions={<Link className="link" href="/admin/quotes">View all</Link>}>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left text-slate-600">
+                <th className="py-2">Quote</th>
+                <th className="py-2">Customer</th>
+                <th className="py-2">Amount</th>
+                <th className="py-2">Status</th>
+                <th className="py-2">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map(r => (
+                <tr key={r.id} className="border-t">
+                  <td className="py-2"><Link className="link" href={`/admin/quotes/${r.id}`}>{r.id}</Link></td>
+                  <td className="py-2">{r.customer}</td>
+                  <td className="py-2">${r.amount.toLocaleString()}</td>
+                  <td className="py-2">{r.status}</td>
+                  <td className="py-2">{r.created}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
     </div>
   );
 }

--- a/src/components/admin/ui/SectionCard.tsx
+++ b/src/components/admin/ui/SectionCard.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+interface SectionCardProps {
+  title: string;
+  children: ReactNode;
+  actions?: ReactNode;
+}
+
+export default function SectionCard({ title, children, actions }: SectionCardProps) {
+  return (
+    <div className="rounded-md border bg-white p-4 shadow-sm space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">{title}</h2>
+        {actions}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/admin/ui/StatCard.tsx
+++ b/src/components/admin/ui/StatCard.tsx
@@ -1,0 +1,36 @@
+import { ArrowDownRight, ArrowUpRight } from 'lucide-react';
+import { ComponentType } from 'react';
+
+interface Trend {
+  dir: 'up' | 'down';
+  value: string;
+}
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  subtext?: string;
+  icon?: ComponentType<{ className?: string }>;
+  trend?: Trend;
+}
+
+export default function StatCard({ title, value, subtext, icon: Icon, trend }: StatCardProps) {
+  return (
+    <div className="p-4 border rounded-md shadow-sm space-y-1">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-slate-600">
+          {Icon && <Icon className="h-5 w-5" />}
+          <span className="text-sm">{title}</span>
+        </div>
+        {trend && (
+          <div className={`flex items-center text-xs ${trend.dir === 'up' ? 'text-green-600' : 'text-red-600'}`}>
+            {trend.dir === 'up' ? <ArrowUpRight className="h-4 w-4" /> : <ArrowDownRight className="h-4 w-4" />}
+            <span className="ml-0.5">{trend.value}</span>
+          </div>
+        )}
+      </div>
+      <div className="text-2xl font-semibold">{value}</div>
+      {subtext && <div className="text-sm text-slate-500">{subtext}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement feature-rich admin dashboard
- extract reusable StatCard and SectionCard components

## Testing
- `npm run lint -- --fix`

------
https://chatgpt.com/codex/tasks/task_e_68aec4a8076883228a8fb3499e967ddf