### PR TITLE
chore: mark supabase pages dynamic and cleanup vercel config

### DIFF
--- a/scripts/codemods/mark-dynamic-node-runtime.mjs
+++ b/scripts/codemods/mark-dynamic-node-runtime.mjs
@@ -1,0 +1,28 @@
+/* eslint-env node */
+import fs from 'node:fs';
+import { globSync } from 'glob';
+
+const files = globSync('src/app/**/page.{ts,tsx}', {
+  nodir: true,
+  windowsPathsNoEscape: true,
+});
+
+const needsRuntime = (s) => /from ['"]@supabase\/ssr['"]/.test(s) || /from ['"]@\/lib\/supabase\/server['"]/.test(s);
+
+for (const f of files) {
+  let s = fs.readFileSync(f, 'utf8');
+  if (!needsRuntime(s)) continue;
+
+  const hasDynamic = /export\s+const\s+dynamic\s*=\s*['"]force-dynamic['"];?/.test(s);
+  const hasRuntime = /export\s+const\s+runtime\s*=\s*['"]nodejs['"];?/.test(s);
+
+  let header = '';
+  if (!hasDynamic) header += "export const dynamic = 'force-dynamic'\n";
+  if (!hasRuntime) header += "export const runtime = 'nodejs'\n";
+
+  if (header) {
+    s = header + '\n' + s;
+    fs.writeFileSync(f, s);
+    console.log('patched dynamic+runtime ->', f);
+  }
+}

--- a/src/app/(customer)/checkout/page.tsx
+++ b/src/app/(customer)/checkout/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 export const runtime = 'nodejs';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import Link from 'next/link';

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import Link from 'next/link';

--- a/vercel.json
+++ b/vercel.json
@@ -3,11 +3,9 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "installCommand": "npm ci --no-audit --prefer-offline",
-  "functions": {
-    "app/**": { "runtime": "nodejs22.x" },
-    "api/**": { "runtime": "nodejs22.x" }
-  },
-  "env": {
-    "NEXT_TELEMETRY_DISABLED": "1"
+  "build": {
+    "env": {
+      "NEXT_TELEMETRY_DISABLED": "1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure signup and signin run on Node runtime and skip prerendering
- strip legacy functions block from vercel.json
- codemod to mark Supabase server pages as dynamic

## Testing
- `npm ci --no-audit --prefer-offline`
- `npm run doctor`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=example npm run verify:strict`


------
https://chatgpt.com/codex/tasks/task_e_68aed30c9f688322a0e994250fd6c8fb