### PR TITLE
Make signup page client-only and dynamic

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,42 +3,45 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import Link from 'next/link';
 
-export default function SignUpPage() {
+export default function SignupPage() {
   const supabase = createClient();
+
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [err, setErr] = useState('');
+  const [err, setErr] = useState<string | null>(null);
   const [ok, setOk] = useState(false);
 
   const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault(); setErr('');
+    e.preventDefault();
+    setErr(null);
     const { error } = await supabase.auth.signUp({ email, password });
-    if (error) { setErr(error.message); return; }
-    setOk(true);
+    if (error) setErr(error.message);
+    else setOk(true);
   };
 
   return (
-    <div className="max-w-md mx-auto card p-6 mt-10">
-      <h1 className="text-xl font-semibold mb-4">Create account</h1>
-      {ok ? (
-        <div className="text-sm">Account created. <Link href="/signin" className="link">Sign in</Link>.</div>
-      ) : (
-        <form onSubmit={onSubmit} className="space-y-3">
-          <div>
-            <label className="text-sm text-slate-600">Email</label>
-            <input type="email" className="mt-1 w-full rounded-xl border px-3 py-2" value={email} onChange={e=>setEmail(e.target.value)} required />
-          </div>
-          <div>
-            <label className="text-sm text-slate-600">Password</label>
-            <input type="password" className="mt-1 w-full rounded-xl border px-3 py-2" value={password} onChange={e=>setPassword(e.target.value)} required />
-          </div>
-          {err && <div className="text-sm text-red-600">{err}</div>}
-          <button type="submit" className="btn btn-primary w-full">Sign up</button>
-        </form>
-      )}
-      <div className="text-sm text-slate-600 mt-3">Have an account? <Link href="/signin" className="link">Sign in</Link></div>
-    </div>
+    <form onSubmit={onSubmit} className="max-w-sm mx-auto p-6 space-y-3">
+      <h1 className="text-xl font-semibold">Create account</h1>
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="border rounded px-3 py-2 w-full"
+        placeholder="you@company.com"
+      />
+      <input
+        type="password"
+        required
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border rounded px-3 py-2 w-full"
+        placeholder="Password"
+      />
+      <button className="px-3 py-2 rounded bg-black text-white">Sign up</button>
+      {err && <div className="text-red-600 text-sm">{err}</div>}
+      {ok && <div className="text-green-700 text-sm">Check your email to verify.</div>}
+    </form>
   );
 }


### PR DESCRIPTION
## Summary
- Make `/signup` a client-only page by adding `'use client'`, forcing dynamic rendering and using the Node.js runtime.
- Switch signup form to use the browser Supabase client within the component and simplify UI.

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee41264848322913b6fdce4b941a3