### PR TITLE
Ensure Supabase client wrappers use correct env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm run dev
 | --- | :---: | --- |
 | `NEXT_PUBLIC_SUPABASE_URL` | ✓ | Supabase project URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✓ | Supabase public anon key |
+| `SUPABASE_URL` | ✓ | Supabase project URL for server usage |
+| `SUPABASE_ANON_KEY` | ✓ | Supabase anon key for server usage |
 | `SUPABASE_SERVICE_ROLE_KEY` | ✓ | Supabase service role key used for server and seeding |
 | `SUPABASE_DB_URL` | ✓ | Direct Postgres connection string for `db:apply` |
 | `STRIPE_SECRET_KEY` |  | Stripe secret key (payments currently stubbed) |

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -2,9 +2,11 @@
 import { createBrowserClient } from '@supabase/ssr';
 
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  if (typeof window === 'undefined') {
+    throw new Error('supabase browser client used on the server');
+  }
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createBrowserClient(url, anon);
 }
 

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -4,15 +4,21 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
 export async function createClient() {
-  const store = await cookies();
-  const get = (name: string) => store.get(name)?.value;
-  const set = (name: string, value: string, options: any) => store.set({ name, value, ...options });
-  const remove = (name: string, options: any) => store.set({ name, value: '', ...options });
-
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { get, set, remove } as any }
-  );
+  const cookieStore = await cookies();
+  const url = process.env.SUPABASE_URL!;
+  const key = process.env.SUPABASE_ANON_KEY!;
+  return createServerClient(url, key, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set() {
+        /* no-op in RSC */
+      },
+      remove() {
+        /* no-op in RSC */
+      }
+    }
+  });
 }
 


### PR DESCRIPTION
## Summary
- Guard browser Supabase client from server-side usage and reference public env vars
- Use private SUPABASE_URL and SUPABASE_ANON_KEY in server client wrapper with cookie helpers
- Document new Supabase server environment variables

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aee4281d5c83229e0a403b5614f1a8