### PR TITLE
Document Supabase env vars for CI and Vercel

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     steps:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ npm run dev
 
 Set `DEMO_MODE=true` in any environment to run without external side effects.
 
+### CI and Vercel environment variables
+
+Because `/signup` is client-only, the public Supabase variables must be available at runtime. In Vercel (Production & Preview) add:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+If any server routes or pages use the Supabase server client, also configure:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY` (or `SUPABASE_SERVICE_ROLE` where appropriate)
+
+For GitHub Actions builds, pass the variables via secrets:
+
+```yaml
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+```
+
+Public keys are safe to expose to the browser; that's how Supabase works.
+
 ## Database
 
 Apply schema and policies to Supabase:


### PR DESCRIPTION
## Summary
- document required Supabase env vars for Vercel and GitHub Actions
- use dedicated public secrets in CI workflow

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68aee467aa288322a2a4fbcb8a7e74b9